### PR TITLE
Add Makefile with on-demand-aware upgrade target (#100)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,183 @@
+# Makefile for nwg-drawer — binary-repo subset per epic §3.6.
+#
+# Default install target is /usr/local (LSB convention for locally-built
+# software). Contributors iterating from a clone should use the no-sudo
+# override:
+#   make install PREFIX=$HOME/.local BINDIR=$HOME/.cargo/bin
+# Go-predecessor parity is an opt-in:
+#   sudo make install PREFIX=/usr
+
+CARGO   ?= cargo
+PREFIX  ?= /usr/local
+BINDIR  ?= $(PREFIX)/bin
+DATADIR ?= $(PREFIX)/share
+DESTDIR ?=
+
+BIN_NAME      := nwg-drawer
+DATA_APP_NAME := nwg-drawer
+
+SONAR_SCANNER ?= /opt/sonar-scanner/bin/sonar-scanner
+SONAR_HOST_URL ?= https://sonar.aaru.network
+SONAR_TRUSTSTORE ?= /tmp/sonar-truststore.jks
+SONAR_TRUSTSTORE_PASSWORD ?= changeit
+
+.PHONY: all build build-release test lint check-tools \
+        lint-fmt lint-clippy lint-test lint-deny lint-audit \
+        install install-bin install-data uninstall \
+        upgrade \
+        sonar clean help
+
+all: build
+
+define HELP_TEXT
+Targets:
+  make build           Debug build
+  make build-release   Release build (used by install + upgrade)
+  make test            cargo test + cargo clippy --all-targets
+  make lint            Full local check: fmt + clippy + test + deny + audit
+  make install         Build release + install binary + install data
+  make install-bin     Install binary to $(DESTDIR)$(BINDIR)
+  make install-data    Install data assets to $(DESTDIR)$(DATADIR)/$(DATA_APP_NAME)/
+  make uninstall       Remove installed binary and data
+  make upgrade         On-demand-aware: rebuild + install; if a resident (`-r`) instance is running, stop it + restart with captured args
+  make sonar           Run SonarQube scan (requires sonar-scanner + .env)
+  make clean           cargo clean
+
+Install-path invocations:
+  sudo make install                                              # default /usr/local
+  make install PREFIX=$$HOME/.local BINDIR=$$HOME/.cargo/bin     # no-sudo dev
+  sudo make install PREFIX=/usr                                  # distro-parity
+endef
+export HELP_TEXT
+
+help:
+	@echo "$$HELP_TEXT"
+
+build:
+	$(CARGO) build
+
+build-release:
+	$(CARGO) build --release
+
+test:
+	$(CARGO) test
+	$(CARGO) clippy --all-targets
+
+check-tools:
+	@if ! command -v cargo-deny >/dev/null 2>&1; then \
+		echo "Installing cargo-deny..."; \
+		$(CARGO) install cargo-deny; \
+	fi
+	@if ! command -v cargo-audit >/dev/null 2>&1; then \
+		echo "Installing cargo-audit..."; \
+		$(CARGO) install cargo-audit; \
+	fi
+
+# Individual lint subtargets — each runnable on its own.
+lint-fmt:
+	@echo "── Format ──"
+	$(CARGO) fmt --all --check
+
+lint-clippy:
+	@echo "── Clippy ──"
+	$(CARGO) clippy --all-targets -- -D warnings
+
+# Plain test (no clippy) so `make lint` runs clippy exactly once via lint-clippy.
+lint-test:
+	@echo "── Tests ──"
+	$(CARGO) test
+
+lint-deny:
+	@echo "── Cargo Deny (licenses, advisories, bans, sources) ──"
+	$(CARGO) deny check
+
+lint-audit:
+	@echo "── Cargo Audit (dependency CVEs) ──"
+	$(CARGO) audit
+
+lint: check-tools lint-fmt lint-clippy lint-test lint-deny lint-audit
+	@echo ""
+	@echo "All local checks passed ✓"
+
+# ─────────────────────────────────────────────────────────────────────
+# Install / uninstall
+# ─────────────────────────────────────────────────────────────────────
+
+install: build-release install-bin install-data
+
+install-bin:
+	@echo "Installing binary to $(DESTDIR)$(BINDIR)/$(BIN_NAME)"
+	install -D -m 755 target/release/$(BIN_NAME) "$(DESTDIR)$(BINDIR)/$(BIN_NAME)"
+
+install-data:
+	@echo "Installing data assets to $(DESTDIR)$(DATADIR)/$(DATA_APP_NAME)/"
+	install -d "$(DESTDIR)$(DATADIR)/$(DATA_APP_NAME)/img"
+	install -m 644 data/$(DATA_APP_NAME)/drawer.css "$(DESTDIR)$(DATADIR)/$(DATA_APP_NAME)/"
+	install -m 644 data/$(DATA_APP_NAME)/img/*.svg "$(DESTDIR)$(DATADIR)/$(DATA_APP_NAME)/img/"
+
+uninstall:
+	@echo "Removing binary + data"
+	rm -f "$(DESTDIR)$(BINDIR)/$(BIN_NAME)"
+	rm -rf "$(DESTDIR)$(DATADIR)/$(DATA_APP_NAME)"
+	@echo "Uninstalled."
+
+# ─────────────────────────────────────────────────────────────────────
+# Upgrade — on-demand-aware.
+# ─────────────────────────────────────────────────────────────────────
+#
+# The drawer is usually spawned per-click from the dock's launcher
+# button, not resident. If no running instance is found, we just
+# rebuild + install — the user's next launch picks up the new binary.
+# If a resident (`-r`) instance IS running, capture its args via
+# --dump-args, stop, install, restart.
+upgrade: build-release
+	@RUNNING_PIDS="$$(pidof -c $(BIN_NAME) 2>/dev/null || true)"; \
+	if [ -n "$$RUNNING_PIDS" ]; then \
+		ARGS_FILE="$$(mktemp)" || exit 1; \
+		trap 'rm -f "$$ARGS_FILE"' EXIT; \
+		for pid in $$RUNNING_PIDS; do \
+			target/release/$(BIN_NAME) --dump-args "$$pid" >> "$$ARGS_FILE" || exit 1; \
+		done; \
+		echo "Resident instance(s) running: $$RUNNING_PIDS — stopping before install"; \
+		kill $$RUNNING_PIDS 2>/dev/null || true; \
+		sleep 1; \
+		$(MAKE) install-bin install-data || exit 1; \
+		if [ -s "$$ARGS_FILE" ]; then \
+			while IFS= read -r args; do \
+				echo "Restarting with captured args: $$args"; \
+				setsid sh -c "$$args" </dev/null >/dev/null 2>&1 & \
+			done < "$$ARGS_FILE"; \
+		fi; \
+	else \
+		echo "No running instance — installing; next drawer launch picks up the new binary"; \
+		$(MAKE) install-bin install-data || exit 1; \
+	fi
+	@echo "Upgrade complete."
+
+# ─────────────────────────────────────────────────────────────────────
+# SonarQube scan — .env is PARSED (never sourced) to avoid shell injection.
+# ─────────────────────────────────────────────────────────────────────
+
+sonar:
+	@echo "Running SonarQube scan..."
+	@test -f ./.env || { echo "ERROR: .env not found in repo root"; exit 1; }
+	@command -v "$(SONAR_SCANNER)" >/dev/null 2>&1 || [ -x "$(SONAR_SCANNER)" ] || { \
+		echo "ERROR: sonar-scanner not found (looked at $(SONAR_SCANNER))"; exit 1; \
+	}
+	@test -r "$(SONAR_TRUSTSTORE)" || { \
+		echo "ERROR: truststore not found or not readable at $(SONAR_TRUSTSTORE)"; \
+		echo "  (sonar.aaru.network uses a self-signed cert — regenerate with:"; \
+		echo "     openssl s_client -connect sonar.aaru.network:443 -showcerts </dev/null 2>/dev/null \\\\"; \
+		echo "       | awk '/BEGIN CERT/,/END CERT/' > /tmp/sonar-cert.pem && \\\\"; \
+		echo "     keytool -importcert -alias sonar-aaru -file /tmp/sonar-cert.pem \\\\"; \
+		echo "       -keystore $(SONAR_TRUSTSTORE) -storepass $(SONAR_TRUSTSTORE_PASSWORD) -noprompt)"; \
+		exit 1; \
+	}
+	@TOKEN="$$(awk '/^SONAR_TOKEN=/{sub(/^[^=]*=[ \t]*/, ""); sub(/[ \t]+$$/, ""); print; exit}' ./.env)"; \
+	test -n "$$TOKEN" || { echo "ERROR: SONAR_TOKEN is empty in .env"; exit 1; }; \
+	SONAR_TOKEN="$$TOKEN" \
+	SONAR_SCANNER_OPTS="-Djavax.net.ssl.trustStore=$(SONAR_TRUSTSTORE) -Djavax.net.ssl.trustStorePassword=$(SONAR_TRUSTSTORE_PASSWORD)" \
+	"$(SONAR_SCANNER)" -Dsonar.host.url="$(SONAR_HOST_URL)"
+
+clean:
+	$(CARGO) clean

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ Targets:
   make install-bin     Install binary to $(DESTDIR)$(BINDIR)
   make install-data    Install data assets to $(DESTDIR)$(DATADIR)/$(DATA_APP_NAME)/
   make uninstall       Remove installed binary and data
-  make upgrade         On-demand-aware: rebuild + install; if a resident (`-r`) instance is running, stop it + restart with captured args
+  make upgrade         On-demand-aware: rebuild + install; if any drawer instance is running (resident or transient), stop + restart with captured args
   make sonar           Run SonarQube scan (requires sonar-scanner + .env)
   make clean           cargo clean
 
@@ -126,10 +126,16 @@ uninstall:
 # ─────────────────────────────────────────────────────────────────────
 #
 # The drawer is usually spawned per-click from the dock's launcher
-# button, not resident. If no running instance is found, we just
+# button, not resident. If no running instance is found we just
 # rebuild + install — the user's next launch picks up the new binary.
-# If a resident (`-r`) instance IS running, capture its args via
-# --dump-args, stop, install, restart.
+# If ANY instance is running (whether resident `-r` or a still-open
+# transient launch) we capture args via --dump-args, stop, install,
+# and restart with the captured args.
+#
+# Linux-only: `pidof` comes from procps-ng and is GNU/Linux-specific.
+# The drawer targets Hyprland + Sway (Linux Wayland compositors), so
+# cross-platform Makefile support is out of scope — if that ever
+# changes, a /proc-based or `pgrep`-based fallback goes here.
 upgrade: build-release
 	@RUNNING_PIDS="$$(pidof -c $(BIN_NAME) 2>/dev/null || true)"; \
 	if [ -n "$$RUNNING_PIDS" ]; then \
@@ -138,9 +144,20 @@ upgrade: build-release
 		for pid in $$RUNNING_PIDS; do \
 			target/release/$(BIN_NAME) --dump-args "$$pid" >> "$$ARGS_FILE" || exit 1; \
 		done; \
-		echo "Resident instance(s) running: $$RUNNING_PIDS — stopping before install"; \
+		echo "Running instance(s): $$RUNNING_PIDS — stopping before install"; \
 		kill $$RUNNING_PIDS 2>/dev/null || true; \
 		sleep 1; \
+		STILL_RUNNING="$$(pidof -c $(BIN_NAME) 2>/dev/null || true)"; \
+		if [ -n "$$STILL_RUNNING" ]; then \
+			echo "Warning: still running after SIGTERM: $$STILL_RUNNING — escalating to SIGKILL"; \
+			kill -9 $$STILL_RUNNING 2>/dev/null || true; \
+			sleep 1; \
+			STILL_RUNNING="$$(pidof -c $(BIN_NAME) 2>/dev/null || true)"; \
+			test -z "$$STILL_RUNNING" || { \
+				echo "ERROR: failed to stop $$STILL_RUNNING after SIGKILL; aborting install to avoid file-in-use"; \
+				exit 1; \
+			}; \
+		fi; \
 		$(MAKE) install-bin install-data || exit 1; \
 		if [ -s "$$ARGS_FILE" ]; then \
 			while IFS= read -r args; do \

--- a/Makefile
+++ b/Makefile
@@ -160,10 +160,19 @@ upgrade: build-release
 		fi; \
 		$(MAKE) install-bin install-data || exit 1; \
 		if [ -s "$$ARGS_FILE" ]; then \
-			while IFS= read -r args; do \
-				echo "Restarting with captured args: $$args"; \
-				setsid sh -c "$$args" </dev/null >/dev/null 2>&1 & \
-			done < "$$ARGS_FILE"; \
+			if [ "$$(id -u)" -eq 0 ]; then \
+				echo "Refusing to replay captured drawer args as root — the captured"; \
+				echo "command came from the desktop user's process and running it via"; \
+				echo "sh -c under elevated privileges would start the drawer in the"; \
+				echo "wrong user context (and execute any desktop-env-derived values"; \
+				echo "in that captured arg string). Install finished; restart the"; \
+				echo "drawer manually from your desktop session."; \
+			else \
+				while IFS= read -r args; do \
+					echo "Restarting with captured args: $$args"; \
+					setsid sh -c "$$args" </dev/null >/dev/null 2>&1 & \
+				done < "$$ARGS_FILE"; \
+			fi; \
 		fi; \
 	else \
 		echo "No running instance — installing; next drawer launch picks up the new binary"; \


### PR DESCRIPTION
## Summary
Per epic §3.6 — drawer's per-repo build / install / upgrade surface. Simpler than the dock's Makefile (no rename, no symlink alias).

Key detail: `make upgrade` is **on-demand-aware**. The drawer is usually spawned per-click from the dock's launcher button rather than running resident. If no live PID is found, `upgrade` just rebuilds + installs — the user's next drawer launch picks up the new binary automatically. If a resident (`-r`) instance IS running, it's captured / stopped / restarted same as the dock's upgrade flow.

All the fail-fast patterns from PR #1 on nwg-dock carry forward:
- `|| exit 1` on mktemp, per-PID `--dump-args`, install-bin/data
- `--dump-args` from `target/release/` (not installed path)
- trap'd tmpfile cleanup
- Sonar target: `.env` parsed via awk (never sourced), preflights for `.env` + scanner + truststore, inline regen recipe in the truststore error

## Install paths (documented in README + `make help`)

| Invocation | BINDIR | DATADIR |
|---|---|---|
| `sudo make install` (default) | `/usr/local/bin` | `/usr/local/share/nwg-drawer/` |
| `make install PREFIX=$HOME/.local BINDIR=$HOME/.cargo/bin` | `~/.cargo/bin` | `~/.local/share/nwg-drawer/` |
| `sudo make install PREFIX=/usr` (distro-parity) | `/usr/bin` | `/usr/share/nwg-drawer/` |

## Test plan
- [x] Sandbox `DESTDIR=/tmp/… make install` lands binary + drawer.css + img/ SVGs
- [x] `make uninstall` clears all three
- [x] `make sonar` uploads to sonar.aaru.network cleanly
- [x] `make -n upgrade` dry-runs under both running-instance and no-running-instance paths
- [ ] CI + CodeRabbit review

Closes #100.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a top-level Makefile providing build, test, lint, install/uninstall, upgrade, SonarQube, clean, and help workflows.
  * Made toolchain, install paths, and SonarQube settings configurable via overrides.
  * Added a composite lint pipeline (format, clippy, tests, dependency and vulnerability checks) and automated SonarQube invocation.
  * Install/uninstall manage binaries and static assets; upgrade captures running instances' args to stop, update, and restart them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->