### PR TITLE
docs: README parity with nwg-dock + nwg-common (badges, install order, 0.3.0 date)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > full pre-split history is preserved in the monorepo's git log; this file
 > only documents changes from v0.3.0 onward.
 
-## [0.3.0] — Unreleased
+## [0.3.0] — 2026-04-20
 
 First standalone release. Extracts the drawer binary from
 [`mac-doc-hyprland`](https://github.com/jasonherald/mac-doc-hyprland) as its

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # nwg-drawer
 
+[![crates.io](https://img.shields.io/crates/v/nwg-drawer.svg)](https://crates.io/crates/nwg-drawer)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 A Launchpad-style application launcher and file search overlay for [Hyprland](https://hyprland.org/), [Sway](https://swaywm.org/), and any Wayland compositor with layer-shell support. Written in Rust.
 
 Ported from [nwg-piotr/nwg-drawer](https://github.com/nwg-piotr/nwg-drawer) (Go) with enhancements: compositor-neutral IPC via the Compositor trait, shared pin state with [`nwg-dock`](https://github.com/jasonherald/nwg-dock), and graceful fallback on unsupported compositors (Niri, river, Openbox).

--- a/README.md
+++ b/README.md
@@ -44,7 +44,17 @@ sudo apt install libgtk-4-dev libgtk4-layer-shell-dev
 sudo dnf install gtk4-devel gtk4-layer-shell-devel
 ```
 
-### `make install` — three invocations
+### From crates.io (recommended for end users)
+
+```bash
+cargo install nwg-drawer
+```
+
+Installs only the binary; the drawer-installed data assets (`drawer.css`, category icons) are not copied. The drawer falls back to its embedded defaults when the filesystem assets are missing, so `cargo install` alone gets you a working drawer; `make install` adds user-customizable CSS and icons at the system location.
+
+### `make install` — for source builds and distro packagers
+
+The Makefile install path drops the binary and the bundled CSS + category icons. Three invocations depending on where the binary should land:
 
 **Default — system-wide (needs sudo):**
 
@@ -67,14 +77,6 @@ make install PREFIX=$HOME/.local BINDIR=$HOME/.cargo/bin
 ```bash
 sudo make install PREFIX=/usr
 ```
-
-### From crates.io
-
-```bash
-cargo install nwg-drawer
-```
-
-Installs only the binary; the drawer-installed data assets (`drawer.css`, category icons) are not copied. The drawer falls back to its embedded defaults when the filesystem assets are missing, so `cargo install` alone gets you a working drawer; `make install` adds user-customizable CSS and icons at the system location.
 
 ## Usage
 


### PR DESCRIPTION
## Summary

- Adds `crates.io` and `License: MIT` shields to the top of the README, matching the badge pattern already used by [`nwg-dock`](https://github.com/jasonherald/nwg-dock) and [`nwg-common`](https://github.com/jasonherald/nwg-common).
- Stamps the `## [0.3.0]` CHANGELOG header with `2026-04-20` (the actual tag date — `nwg-drawer` 0.3.0 has been live on crates.io since 2026-04-21, but the changelog still read "Unreleased").
- Reorders the `## Install` section to mirror `nwg-dock`: `cargo install` first ("recommended for end users"), `make install` second ("for source builds and distro packagers"). Same content, resequenced.

Doc-only — no source, `Cargo.toml`, or `Cargo.lock` changes; no republish needed.

## Test plan

- [x] `make lint` (no Rust changed, but ran for hygiene)
- [x] `cargo publish --dry-run --allow-dirty` confirms 0.3.0 is unchanged on crates.io (the "already exists" warning is the desired no-op)
- [x] Verified install-path claims in README against `Makefile` (`/usr/local/bin/nwg-drawer`, `/usr/local/share/nwg-drawer/{drawer.css,img/}`, `PREFIX=$HOME/.local BINDIR=$HOME/.cargo/bin`, `PREFIX=/usr`)
- [x] Visual diff against `nwg-dock` and `nwg-common` README — heading hierarchy, badge placement, install-section ordering all match

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Version 0.3.0 officially released (April 20, 2026).
  * Installation documentation enhanced with clearer guidance on the recommended crates.io method via `cargo install`.
  * Make install instructions expanded to cover three installation modes for different deployment scenarios.
  * Added crates.io and MIT badges to project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->