### PR TITLE
docs: fix Issue 17 heading (three → four patterns)

### DIFF
--- a/docs/code-review-2026-05.md
+++ b/docs/code-review-2026-05.md
@@ -281,7 +281,7 @@ Targeted, not bulk. Specifically:
 
 ### Wave 6 — refactor consolidation
 
-#### Issue 17: Consolidate three duplicated patterns into helpers
+#### Issue 17: Consolidate four duplicated patterns into helpers
 
 - **Severity:** med · **Effort:** S · **Labels:** `refactor`, `cleanup`
 - **Source:** A-F3, A-F4, A-F6, A-F7


### PR DESCRIPTION
## Summary

The Issue 17 heading in `docs/code-review-2026-05.md` says "Consolidate **three** duplicated patterns into helpers" but the body lists four numbered items (the count grew when the wave was assembled — `pinned.rs` deletion + the new `clear_box` / `observe_children` consolidation). GH issue #45 already retitled to match the body; this brings the doc into sync.

## Test plan

- [x] One-line edit; doc-only
- [x] Body content unchanged
- [x] GH issue #45 title already updated to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated internal documentation to reflect consolidation of duplicate patterns into helper functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->