### PR TITLE
Fix file-search path display: sibling-dir + unset-HOME bugs (Wave 2, #33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pin-toggle save failure no longer silently reorders the pinned row — the
   rollback path now restores the unpinned item at its original position
   instead of appending it. Pre-existing latent bug surfaced during #30.
+- File-search path display now correctly handles sibling directories of
+  `$HOME` and the case where `$HOME` is unset. Previously `/home/userfoo/Docs`
+  would render as `~foo/Docs` (sibling of `/home/user`), and an unset `$HOME`
+  caused every path to gain a leading `~`. Resolves #33.
 
 ### Removed
 

--- a/src/ui/file_search.rs
+++ b/src/ui/file_search.rs
@@ -205,11 +205,7 @@ fn file_result_row(
         .to_string();
     // Shorten home prefix
     let home = std::env::var("HOME").unwrap_or_default();
-    let short_path = if parent.starts_with(&home) {
-        format!("~{}", &parent[home.len()..])
-    } else {
-        parent
-    };
+    let short_path = shorten_home(&parent, &home);
     let path_label = gtk4::Label::new(Some(&short_path));
     path_label.set_halign(gtk4::Align::Start);
     path_label.set_hexpand(true);
@@ -242,6 +238,23 @@ fn file_result_row(
     button
 }
 
+/// Replaces a leading `home` directory in `parent` with `~`.
+///
+/// Component-aware via `Path::strip_prefix`, so `/home/user` does not
+/// prefix-match `/home/userfoo` (a sibling, not a child). Returns `parent`
+/// unchanged when `home` is empty (e.g. `$HOME` unset) or when `parent` is
+/// not under `home`.
+fn shorten_home(parent: &str, home: &str) -> String {
+    if home.is_empty() {
+        return parent.to_string();
+    }
+    match std::path::Path::new(parent).strip_prefix(std::path::Path::new(home)) {
+        Ok(rest) if rest.as_os_str().is_empty() => "~".to_string(),
+        Ok(rest) => format!("~/{}", rest.to_string_lossy()),
+        Err(_) => parent.to_string(),
+    }
+}
+
 fn file_type_icon(path: &Path) -> &'static str {
     let ext = path
         .extension()
@@ -262,5 +275,53 @@ fn file_type_icon(path: &Path) -> &'static str {
         "ppt" | "pptx" | "odp" => "x-office-presentation",
         "3mf" | "stl" | "obj" | "step" | "stp" => "application-x-blender",
         _ => "text-x-generic",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::shorten_home;
+
+    #[test]
+    fn shortens_path_under_home() {
+        assert_eq!(shorten_home("/home/user/Docs", "/home/user"), "~/Docs");
+    }
+
+    #[test]
+    fn handles_exact_home_match() {
+        assert_eq!(shorten_home("/home/user", "/home/user"), "~");
+    }
+
+    #[test]
+    fn handles_nested_path() {
+        assert_eq!(shorten_home("/home/user/a/b/c", "/home/user"), "~/a/b/c");
+    }
+
+    #[test]
+    fn handles_trailing_slash_on_home() {
+        assert_eq!(shorten_home("/home/user/Docs", "/home/user/"), "~/Docs");
+    }
+
+    #[test]
+    fn returns_parent_unchanged_when_outside_home() {
+        assert_eq!(shorten_home("/etc/foo", "/home/user"), "/etc/foo");
+    }
+
+    #[test]
+    fn does_not_match_sibling_directory() {
+        // /home/userfoo is a sibling of /home/user, not a child. The
+        // String::starts_with check incorrectly matches here, producing
+        // "~foo/Docs" instead of leaving the path alone.
+        assert_eq!(
+            shorten_home("/home/userfoo/Docs", "/home/user"),
+            "/home/userfoo/Docs"
+        );
+    }
+
+    #[test]
+    fn returns_parent_unchanged_when_home_unset() {
+        // When $HOME is unset we get an empty string, and "".starts_with("")
+        // is always true — so every path used to gain a leading "~".
+        assert_eq!(shorten_home("/etc/something", ""), "/etc/something");
     }
 }


### PR DESCRIPTION
## Summary

Closes #33. First Wave 2 issue from the [code-review epic](#28).

Extracted `shorten_home(parent, home) -> String` from the inline `~` substitution in `file_result_row` and fixed two pre-existing latent bugs along the way.

## The bugs

| Input | Before | After |
|---|---|---|
| `parent="/home/userfoo/Docs"`, `home="/home/user"` | `~foo/Docs` ❌ | `/home/userfoo/Docs` ✅ |
| `parent="/etc/something"`, `home=""` (unset `$HOME`) | `~/etc/something` ❌ | `/etc/something` ✅ |
| `parent="/home/user/Docs"`, `home="/home/user/"` | `~Docs` ❌ | `~/Docs` ✅ |

Root cause: `String::starts_with` doesn't respect path component boundaries, and `"".starts_with("")` is always true. The fix uses `Path::strip_prefix` which is component-aware, plus an explicit short-circuit when `home` is empty.

## TDD note

Wrote the tests first against the **extracted-but-still-buggy** implementation. Three bug-class tests failed on the buggy code (sibling-dir, trailing-slash-on-home, unset-HOME); the four correct-behavior tests passed. Then swapped the implementation for the `Path::strip_prefix` version and all seven turned green. Captures the bugs in tests before they're fixed, so any future regression surfaces immediately.

## Test plan

- [x] 7 new unit tests in `src/ui/file_search.rs`: normal-under-home, exact-home, nested, trailing-slash-on-home, outside-home, sibling-dir (regression), unset-HOME (regression)
- [x] All pass: `cargo test --bin nwg-drawer ui::file_search::tests`
- [x] `make lint` clean (fmt + clippy + test + deny + audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed file path display in search results. Home directory shortcuts now render correctly, with proper handling for sibling directories and cases where the home directory is unset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->