### PR TITLE
Add unit-test coverage for file_search walk + helpers (Wave 2, #32)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,6 +227,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "exmex"
 version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,6 +249,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "field-offset"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,6 +263,12 @@ dependencies = [
  "memoffset",
  "rustc_version",
 ]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "fsevent-sys"
@@ -386,6 +408,19 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -629,6 +664,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
@@ -640,13 +684,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -738,6 +790,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -751,6 +809,12 @@ checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -869,7 +933,14 @@ dependencies = [
  "nwg-common",
  "serde",
  "serde_json",
+ "tempfile",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -935,6 +1006,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -962,12 +1043,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
  "libredox",
  "thiserror",
 ]
@@ -1008,6 +1095,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1132,6 +1232,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1209,6 +1322,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1235,6 +1354,58 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.1",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
 
 [[package]]
 name = "winapi-util"
@@ -1341,6 +1512,100 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.1",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,7 @@ nix = { version = "0.31", features = ["signal", "process", "fs"] }
 # Math expression evaluation (search-bar calculator).
 # Migrated off `meval` because its nom 1.2.4 transitive dep was unmaintained.
 exmex = "0.20"
+
+[dev-dependencies]
+# Filesystem fixtures for unit tests (walk_directory, etc.).
+tempfile = "3"

--- a/src/ui/file_search.rs
+++ b/src/ui/file_search.rs
@@ -280,7 +280,11 @@ fn file_type_icon(path: &Path) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use super::shorten_home;
+    use super::*;
+    use std::fs;
+    use std::path::Path;
+
+    // ── shorten_home ────────────────────────────────────────────────────
 
     #[test]
     fn shortens_path_under_home() {
@@ -323,5 +327,195 @@ mod tests {
         // When $HOME is unset we get an empty string, and "".starts_with("")
         // is always true — so every path used to gain a leading "~".
         assert_eq!(shorten_home("/etc/something", ""), "/etc/something");
+    }
+
+    // ── is_excluded ─────────────────────────────────────────────────────
+
+    #[test]
+    fn is_excluded_returns_false_for_empty_list() {
+        assert!(!is_excluded("any/path/here", &[]));
+    }
+
+    #[test]
+    fn is_excluded_matches_substring() {
+        // The check is `relative.contains(ex)` — a literal substring match,
+        // not a glob or path-component match. Pin that behavior so future
+        // refactors don't silently change semantics across user setups.
+        assert!(is_excluded(
+            "myproject/target/build.rs",
+            &["target".to_string()]
+        ));
+    }
+
+    #[test]
+    fn is_excluded_substring_match_catches_node_modules_via_node() {
+        // Documented gotcha: the substring rule means an exclusion of
+        // `"node"` also excludes anything containing `node` — including
+        // `node_modules`, `nodemcu/`, etc.
+        assert!(is_excluded(
+            "frontend/node_modules/x",
+            &["node".to_string()]
+        ));
+    }
+
+    // ── file_type_icon ──────────────────────────────────────────────────
+
+    #[test]
+    fn file_type_icon_recognized_extensions() {
+        assert_eq!(file_type_icon(Path::new("doc.pdf")), "application-pdf");
+        assert_eq!(file_type_icon(Path::new("clip.mp4")), "video-x-generic");
+        assert_eq!(file_type_icon(Path::new("song.mp3")), "audio-x-generic");
+        assert_eq!(
+            file_type_icon(Path::new("archive.zst")),
+            "package-x-generic"
+        );
+        assert_eq!(file_type_icon(Path::new("main.rs")), "text-x-script");
+        assert_eq!(file_type_icon(Path::new("page.html")), "text-html");
+    }
+
+    #[test]
+    fn file_type_icon_unknown_extension_falls_back() {
+        assert_eq!(file_type_icon(Path::new("blob.xyz")), "text-x-generic");
+    }
+
+    #[test]
+    fn file_type_icon_no_extension_falls_back() {
+        assert_eq!(file_type_icon(Path::new("README")), "text-x-generic");
+    }
+
+    #[test]
+    fn file_type_icon_is_case_insensitive() {
+        // Pinned: extension lookup lowercases the input. Otherwise common
+        // shouty filenames like `.PDF` or `.JPG` wouldn't match.
+        assert_eq!(file_type_icon(Path::new("scan.PDF")), "application-pdf");
+        assert_eq!(file_type_icon(Path::new("photo.JPG")), "image-x-generic");
+    }
+
+    // ── walk_directory ──────────────────────────────────────────────────
+    //
+    // Fixture helper: lays down a directory tree under `root` from a list of
+    // (relative-path, kind) tuples. Files get touched empty; "dir" entries
+    // create directories.
+    fn build_tree(root: &Path, entries: &[(&str, &str)]) {
+        for (rel, kind) in entries {
+            let full = root.join(rel);
+            match *kind {
+                "dir" => fs::create_dir_all(&full).expect("create_dir_all"),
+                _ => {
+                    if let Some(parent) = full.parent() {
+                        fs::create_dir_all(parent).expect("create_dir_all parent");
+                    }
+                    fs::File::create(&full).expect("touch file");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn walk_directory_caps_results_at_max() {
+        let root = tempfile::tempdir().expect("tempdir");
+        // 30 matching files spread across 3 nesting levels.
+        let mut entries = Vec::new();
+        for i in 0..10 {
+            entries.push((format!("match-top-{}.txt", i), "file".to_string()));
+        }
+        for i in 0..10 {
+            entries.push((format!("a/match-mid-{}.txt", i), "file".to_string()));
+        }
+        for i in 0..10 {
+            entries.push((format!("a/b/match-deep-{}.txt", i), "file".to_string()));
+        }
+        let entries_ref: Vec<(&str, &str)> = entries
+            .iter()
+            .map(|(p, k)| (p.as_str(), k.as_str()))
+            .collect();
+        build_tree(root.path(), &entries_ref);
+
+        let results = walk_directory(root.path(), "match", &[], 7);
+        assert!(
+            results.len() <= 7,
+            "expected ≤7 results, got {}",
+            results.len()
+        );
+    }
+
+    #[test]
+    fn walk_directory_skips_excluded_subtree() {
+        let root = tempfile::tempdir().expect("tempdir");
+        build_tree(
+            root.path(),
+            &[
+                ("src/note.txt", "file"),
+                ("target/note.txt", "file"),
+                ("docs/note.txt", "file"),
+            ],
+        );
+
+        let results = walk_directory(root.path(), "note", &["target".to_string()], 100);
+        let paths: Vec<String> = results
+            .iter()
+            .map(|r| r.path.to_string_lossy().to_string())
+            .collect();
+        assert!(
+            paths.iter().any(|p| p.contains("src/note.txt")),
+            "missing src result; got {:?}",
+            paths
+        );
+        assert!(
+            paths.iter().any(|p| p.contains("docs/note.txt")),
+            "missing docs result; got {:?}",
+            paths
+        );
+        assert!(
+            !paths.iter().any(|p| p.contains("target/note.txt")),
+            "target should be excluded; got {:?}",
+            paths
+        );
+    }
+
+    #[test]
+    fn walk_directory_does_not_panic_on_unreadable_subdir() {
+        // A directory we can't read (e.g. permissions failure) must not
+        // panic the walk — `read_dir` errors are swallowed via `match … Err
+        // => return`. Pin that behavior so a future refactor that introduces
+        // an `unwrap` here doesn't crash the drawer's file search on a user's
+        // tree.
+        let root = tempfile::tempdir().expect("tempdir");
+        build_tree(
+            root.path(),
+            &[("readable/match.txt", "file"), ("locked", "dir")],
+        );
+
+        // Drop read permission on the locked dir. If chmod fails (e.g. ACLs
+        // or unusual filesystem), skip rather than fail the test — we're
+        // pinning behavior, not testing chmod itself.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let locked = root.path().join("locked");
+            fs::create_dir_all(locked.join("inner")).ok();
+            fs::File::create(locked.join("inner/match-locked.txt")).ok();
+            let perms = fs::Permissions::from_mode(0o000);
+            if fs::set_permissions(&locked, perms).is_err() {
+                return;
+            }
+
+            // Should return without panicking. The unreadable subtree is
+            // silently skipped; the readable one is still walked.
+            let results = walk_directory(root.path(), "match", &[], 100);
+            let paths: Vec<String> = results
+                .iter()
+                .map(|r| r.path.to_string_lossy().to_string())
+                .collect();
+            assert!(
+                paths.iter().any(|p| p.contains("readable/match.txt")),
+                "readable subtree should still be walked; got {:?}",
+                paths
+            );
+
+            // Restore permissions so tempfile cleanup can recurse into the
+            // dir to remove it.
+            let _ = fs::set_permissions(&locked, fs::Permissions::from_mode(0o755));
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #32. Second Wave 2 issue from the [code-review epic](#28).

Pins behavior across three orthogonal helpers in `src/ui/file_search.rs` that had no tests today: `walk_directory`, `is_excluded`, and `file_type_icon`.

## What's covered

### `walk_directory` — 3 tests, tempfile fixtures

| Test | Pins what |
|---|---|
| `walk_directory_caps_results_at_max` | 30 matching files across 3 nesting levels; walk with `max=7` returns ≤7. Catches the "cap leak past one level" regression class — exactly what would freeze the drawer for seconds on every keystroke against a heavy `~/Downloads`. |
| `walk_directory_skips_excluded_subtree` | Exclusion `target` skips `target/` but leaves `src/` and `docs/` reachable. |
| `walk_directory_does_not_panic_on_unreadable_subdir` | `chmod 000` on a subdir; walk completes without panic and the readable subtree is still returned. Unix-only via `cfg(unix)`. Pins the existing `match read_dir { Err => return }` behavior so a future refactor that introduces an `unwrap` here doesn't crash file-search on a user's tree. |

### `is_excluded` — 3 tests

- Empty exclusion list returns `false`.
- Substring semantics pinned: `target` catches `myproject/target/x`.
- Documented gotcha pinned: `node` exclusion catches `node_modules` (substring, not glob).

### `file_type_icon` — 4 tests

- Recognized extensions: pdf, mp4, mp3, zst, rs, html.
- Unknown ext falls back to `text-x-generic`.
- No-extension falls back.
- Case-insensitive (`.PDF == .pdf`).

## Dev-dep added

`Cargo.toml` gains a `[dev-dependencies]` block with `tempfile = "3"` — matches the same dep on the sibling `nwg-dock` crate.

## Test plan

- [x] `cargo test --bin nwg-drawer ui::file_search::tests` — 17 pass (10 new + 7 existing from #33)
- [x] `make lint` clean (fmt + clippy + test + deny + audit)
- [x] No production-code changes — pure test additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added development testing infrastructure and expanded test coverage with comprehensive new test cases to validate functionality and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->