### PR TITLE
Make build_app_flow_box take &WellContext (Wave 3, #36)

### DIFF
--- a/src/ui/app_grid.rs
+++ b/src/ui/app_grid.rs
@@ -1,6 +1,7 @@
 use crate::config::DrawerConfig;
 use crate::state::DrawerState;
 use crate::ui::search::subsequence_match;
+use crate::ui::well_context::WellContext;
 use crate::ui::widgets;
 use gtk4::prelude::*;
 use nwg_common::desktop::entry::DesktopEntry;
@@ -9,19 +10,18 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 /// Creates the app FlowBox with optional category filter and search.
-#[allow(clippy::too_many_arguments)]
+///
+/// Reads `config`, `state`, `pinned_file`, `on_launch`, and `status_label`
+/// from `ctx`. Per-call inputs (filter, phrase, rebuild callback) stay as
+/// explicit parameters because callers vary on each.
 pub fn build_app_flow_box(
-    config: &DrawerConfig,
-    state: &Rc<RefCell<DrawerState>>,
+    ctx: &WellContext,
     category_filter: Option<&[String]>,
     search_phrase: &str,
-    pinned_file: &std::path::Path,
-    on_launch: Rc<dyn Fn()>,
-    status_label: &gtk4::Label,
     on_rebuild: Option<&Rc<dyn Fn()>>,
 ) -> gtk4::FlowBox {
-    let flow_box = create_flow_box(config);
-    let entries = state.borrow().apps.entries.clone();
+    let flow_box = create_flow_box(&ctx.config);
+    let entries = ctx.state.borrow().apps.entries.clone();
     let needle = search_phrase.to_lowercase();
 
     for entry in &entries {
@@ -44,11 +44,11 @@ pub fn build_app_flow_box(
         if show {
             let button = build_button(
                 entry,
-                config,
-                state,
-                pinned_file,
-                &on_launch,
-                status_label,
+                &ctx.config,
+                &ctx.state,
+                &ctx.pinned_file,
+                &ctx.on_launch,
+                &ctx.status_label,
                 on_rebuild,
             );
             insert_into_flow(&flow_box, &button);

--- a/src/ui/categories.rs
+++ b/src/ui/categories.rs
@@ -106,16 +106,7 @@ pub fn apply_category_filter(ctx: &WellContext, category_ids: &[String]) {
     }
 
     let on_rebuild = ui::well_builder::build_rebuild_callback(ctx);
-    let flow = ui::app_grid::build_app_flow_box(
-        &ctx.config,
-        &ctx.state,
-        Some(category_ids),
-        "",
-        &ctx.pinned_file,
-        Rc::clone(&ctx.on_launch),
-        &ctx.status_label,
-        Some(&on_rebuild),
-    );
+    let flow = ui::app_grid::build_app_flow_box(ctx, Some(category_ids), "", Some(&on_rebuild));
     flow.set_halign(gtk4::Align::Center);
     ctx.well.append(&flow);
 

--- a/src/ui/well_builder.rs
+++ b/src/ui/well_builder.rs
@@ -26,16 +26,7 @@ pub fn build_normal_well(ctx: &WellContext) {
     }
 
     // App grid (scrollable)
-    let flow = ui::app_grid::build_app_flow_box(
-        &ctx.config,
-        &ctx.state,
-        None,
-        "",
-        &ctx.pinned_file,
-        Rc::clone(&ctx.on_launch),
-        &ctx.status_label,
-        Some(&on_rebuild),
-    );
+    let flow = ui::app_grid::build_app_flow_box(ctx, None, "", Some(&on_rebuild));
     flow.set_halign(gtk4::Align::Center);
     ctx.well.append(&flow);
 
@@ -82,16 +73,7 @@ pub fn build_search_results(ctx: &WellContext, phrase: &str) {
     // Rebuild callback — rebuild_preserving_category checks active_search
     // and will re-run the search instead of restoring normal view.
     let on_rebuild = build_rebuild_callback(ctx);
-    let app_flow = ui::app_grid::build_app_flow_box(
-        &ctx.config,
-        &ctx.state,
-        None,
-        phrase,
-        &ctx.pinned_file,
-        Rc::clone(&ctx.on_launch),
-        &ctx.status_label,
-        Some(&on_rebuild),
-    );
+    let app_flow = ui::app_grid::build_app_flow_box(ctx, None, phrase, Some(&on_rebuild));
     app_flow.set_halign(gtk4::Align::Center);
     ctx.well.append(&app_flow);
 


### PR DESCRIPTION
## Summary

Closes #36. Wave 3 follow-on to #34 ([the main.rs split](#57)).

`build_app_flow_box` was the second `#[allow(clippy::too_many_arguments)]` smell in the codebase. The 8-parameter signature unpacked five values from a `WellContext` that all three callers already had on hand — exactly what `WellContext` exists to eliminate.

## Diff shape

| File | Change |
|---|---|
| `src/ui/app_grid.rs` | Signature collapses 8 params → 4. Body reads `&ctx.config`, `&ctx.state`, `&ctx.pinned_file`, `&ctx.on_launch`, `&ctx.status_label` instead of taking each individually. `#[allow(clippy::too_many_arguments)]` gone. |
| `src/ui/well_builder.rs` (2 call sites) | `build_normal_well` and `build_search_results` each collapse from 9-line argument lists to one-liners. |
| `src/ui/categories.rs` (1 call site) | `apply_category_filter` same. |

Net `+16 / -43`.

New signature:

```rust
pub fn build_app_flow_box(
    ctx: &WellContext,
    category_filter: Option<&[String]>,
    search_phrase: &str,
    on_rebuild: Option<&Rc<dyn Fn()>>,
) -> gtk4::FlowBox
```

## Why `on_rebuild` stays separate (not pulled from ctx)

`well_builder::build_normal_well` and `build_search_results` create one `Rc<dyn Fn()>` rebuild callback and share it between `build_pinned_flow` and `build_app_flow_box`. Moving the construction inside `build_app_flow_box` would force a second allocation per render. The current pattern keeps the one-callback-per-rebuild invariant.

## Verified

- [x] `cargo build` clean
- [x] `make lint` clean (fmt + clippy + test + deny + audit)
- [x] `grep -rn "too_many_arguments" src/` returns zero hits — both `activate_drawer` (killed by #34) and `build_app_flow_box` (killed here) allows are gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code restructuring to streamline configuration management and improve code maintainability. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->