### PR TITLE
Trim ui/math.rs: split widget out, retire static-Once CSS injection (Wave 3, #35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   denied, broken symlink, etc.) no longer hide the app entirely — the
   launcher now falls through to the system-wide copy. Previously a single
   bad user override caused the app to disappear from the grid.
+- Math result "Copy" button now copies negative results correctly. Values
+  like `-5` or `-3.14` previously failed silently because `wl-copy` parsed
+  the leading `-` as an unknown flag.
 
 ### Removed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,8 @@ src/
     ├── search_handler.rs
     ├── app_grid.rs, file_search.rs
     ├── widgets.rs
-    ├── math.rs           # exmex-based expression evaluator (see Conventions)
+    ├── math.rs           # exmex-based expression evaluator + tests (see Conventions)
+    ├── math_widget.rs    # GTK widget builder for the inline math result row
     ├── categories.rs
     ├── power_bar.rs
     ├── search.rs

--- a/src/assets/drawer.css
+++ b/src/assets/drawer.css
@@ -162,3 +162,37 @@ window.drawer-backdrop {
 flowboxchild {
     padding: 4px;
 }
+
+/* Inline math result row.
+ * Shown above the file-search list when the search phrase parses as a
+ * math expression. The "Copy" button shells out to wl-copy on click and
+ * surfaces a "Copied!" confirmation that auto-hides after 2 seconds.
+ *
+ * Sizing (font-size, padding, border-radius) was previously held in
+ * ui/constants.rs and runtime-injected via a `static Once` block; moved
+ * into this static stylesheet alongside the rest of the drawer's styles
+ * (issue #35). */
+.math-result {
+    font-size: 20px;
+    font-weight: bold;
+    margin-right: 12px;
+}
+.math-divider {
+    margin-left: 0;
+    margin-right: 0;
+}
+.math-copy {
+    font-size: 20px;
+    background: #5b9bd5;
+    color: white;
+    border-radius: 6px;
+    padding: 4px 16px;
+    margin-left: 12px;
+}
+.math-copy:hover {
+    background: #4a8bc2;
+}
+.math-copied {
+    color: #5b9bd5;
+    font-style: italic;
+}

--- a/src/ui/constants.rs
+++ b/src/ui/constants.rs
@@ -54,5 +54,12 @@ pub const DIVIDER_SIDE_MARGIN: i32 = 16;
 /// Vertical spacing between math result row and "Copied!" label.
 pub const MATH_VBOX_SPACING: i32 = 4;
 
+/// Horizontal spacing between widgets within the math result row
+/// (label / divider / copy button). The label sets its own right-margin
+/// via the `.math-result` CSS rule and the copy button sets its own
+/// left-margin via `.math-copy`, so the box-level spacing is intentionally
+/// 0 — having both wouldn't compose visibly.
+pub const MATH_ROW_SPACING: i32 = 0;
+
 /// Duration in seconds before the "Copied!" confirmation label auto-hides.
 pub const COPIED_LABEL_TIMEOUT_SECS: u64 = 2;

--- a/src/ui/constants.rs
+++ b/src/ui/constants.rs
@@ -46,18 +46,10 @@ pub const DIVIDER_VERTICAL_MARGIN: i32 = 8;
 /// Side margin for section dividers (left/right padding).
 pub const DIVIDER_SIDE_MARGIN: i32 = 16;
 
-/// Font size for inline math result text and copy button.
-pub const MATH_FONT_SIZE: i32 = 20;
-
-/// Horizontal margin between math result/button and the divider.
-pub const MATH_SPACING: i32 = 12;
-
-/// Border radius for the math copy button.
-pub const MATH_BORDER_RADIUS: i32 = 6;
-
-/// Vertical/horizontal padding inside the math copy button.
-pub const MATH_BUTTON_PADDING_V: i32 = 4;
-pub const MATH_BUTTON_PADDING_H: i32 = 16;
+// Math result-row sizing (font-size, spacing, border-radius, padding) lives
+// in `assets/drawer.css` under the `.math-result` / `.math-copy` rules
+// rather than here — those values are only consumed by the static stylesheet,
+// not by Rust-side widget construction. See issue #35.
 
 /// Vertical spacing between math result row and "Copied!" label.
 pub const MATH_VBOX_SPACING: i32 = 4;

--- a/src/ui/math.rs
+++ b/src/ui/math.rs
@@ -1,5 +1,14 @@
+//! Pure inline math evaluator for the search bar.
+//!
+//! `eval_expression` parses the search phrase via `exmex`, returning
+//! [`MathResult`]. `format_result` renders an `f64` for display in the
+//! well — handles integer / decimal / scientific notation, FP-noise
+//! snap-to-zero, and -0 normalization.
+//!
+//! The widget that surfaces this in GTK lives in [`super::math_widget`];
+//! this module has zero GTK deps and is fully unit-testable.
+
 use exmex::{BinOp, Express, FlatEx, FloatOpsFactory, MakeOperators, Operator};
-use gtk4::prelude::*;
 
 /// Result of attempting to evaluate a math expression.
 #[derive(Debug)]
@@ -82,155 +91,11 @@ pub fn eval_expression(expr: &str) -> MathResult {
     }
 }
 
-/// Builds an inline math result widget for the search well.
-/// Returns `None` if the phrase isn't a math expression.
-pub fn build_math_result(phrase: &str) -> Option<gtk4::Box> {
-    let (label_text, result_str) = match eval_expression(phrase) {
-        MathResult::Value(val) => {
-            let r = format_result(val);
-            (format!("{} = {}", phrase, r), Some(r))
-        }
-        MathResult::Error(msg) => (format!("{} — {}", phrase, msg), None),
-        MathResult::NotMath => return None,
-    };
-
-    let vbox = gtk4::Box::new(
-        gtk4::Orientation::Vertical,
-        super::constants::MATH_VBOX_SPACING,
-    );
-    vbox.set_halign(gtk4::Align::Center);
-    vbox.set_margin_top(super::constants::STATUS_AREA_VERTICAL_MARGIN);
-    vbox.set_margin_bottom(super::constants::STATUS_AREA_VERTICAL_MARGIN);
-    // Don't set focusable(false) — the capture-phase key controller needs
-    // the container to participate in event dispatch for arrow key navigation.
-
-    let row = gtk4::Box::new(gtk4::Orientation::Horizontal, 0);
-    row.set_halign(gtk4::Align::Center);
-
-    let label = gtk4::Label::new(Some(&label_text));
-    label.add_css_class("math-result");
-    label.set_halign(gtk4::Align::End);
-    label.set_focusable(false);
-    row.append(&label);
-
-    if let Some(result_copy) = result_str {
-        append_copy_button(&row, &vbox, result_copy);
-    } else {
-        vbox.append(&row);
-    }
-
-    // Capture-phase key controller on the vbox (parent) — fires before
-    // GTK's focus machinery processes arrow keys on the child Copy button.
-    // Same pattern as install_grid_nav on FlowBoxes (navigation.rs).
-    let vbox_weak = vbox.downgrade();
-    let nav_ctrl = gtk4::EventControllerKey::new();
-    nav_ctrl.set_propagation_phase(gtk4::PropagationPhase::Capture);
-    nav_ctrl.connect_key_pressed(move |_, keyval, _, _| {
-        let Some(vbox_ref) = vbox_weak.upgrade() else {
-            return gtk4::glib::Propagation::Proceed;
-        };
-        match keyval {
-            gtk4::gdk::Key::Down | gtk4::gdk::Key::Tab => {
-                if super::navigation::focus_next_sibling(&vbox_ref) {
-                    gtk4::glib::Propagation::Stop
-                } else {
-                    gtk4::glib::Propagation::Proceed
-                }
-            }
-            gtk4::gdk::Key::Up | gtk4::gdk::Key::ISO_Left_Tab => {
-                if super::navigation::focus_prev_sibling(&vbox_ref) {
-                    gtk4::glib::Propagation::Stop
-                } else {
-                    gtk4::glib::Propagation::Proceed
-                }
-            }
-            _ => gtk4::glib::Propagation::Proceed,
-        }
-    });
-    vbox.add_controller(nav_ctrl);
-
-    // Load math CSS once (dimensions from ui/constants.rs)
-    use super::constants::{
-        MATH_BORDER_RADIUS, MATH_BUTTON_PADDING_H, MATH_BUTTON_PADDING_V, MATH_FONT_SIZE,
-        MATH_SPACING,
-    };
-    static CSS_LOADED: std::sync::Once = std::sync::Once::new();
-    CSS_LOADED.call_once(|| {
-        let provider = gtk4::CssProvider::new();
-        provider.load_from_data(&format!(
-            ".math-result {{ font-size: {fs}px; font-weight: bold; margin-right: {sp}px; }} \
-             .math-divider {{ margin-left: 0px; margin-right: 0px; }} \
-             .math-copy {{ font-size: {fs}px; background: #5b9bd5; color: white; border-radius: {br}px; padding: {pv}px {ph}px; margin-left: {sp}px; }} \
-             .math-copy:hover {{ background: #4a8bc2; }} \
-             .math-copied {{ color: #5b9bd5; font-style: italic; }}",
-            fs = MATH_FONT_SIZE,
-            sp = MATH_SPACING,
-            br = MATH_BORDER_RADIUS,
-            pv = MATH_BUTTON_PADDING_V,
-            ph = MATH_BUTTON_PADDING_H,
-        ));
-        if let Some(display) = gtk4::gdk::Display::default() {
-            gtk4::style_context_add_provider_for_display(
-                &display,
-                &provider,
-                gtk4::STYLE_PROVIDER_PRIORITY_APPLICATION,
-            );
-        }
-    });
-
-    Some(vbox)
-}
-
-/// Appends a copy button and "Copied!" label to the math result row.
-/// Copies the result to clipboard via wl-copy on click, with a 2-second
-/// confirmation label that resets on repeated clicks.
-fn append_copy_button(row: &gtk4::Box, vbox: &gtk4::Box, result_copy: String) {
-    let sep = gtk4::Separator::new(gtk4::Orientation::Vertical);
-    sep.add_css_class("math-divider");
-    row.append(&sep);
-
-    let copy_btn = gtk4::Button::with_label("Copy");
-    copy_btn.add_css_class("math-copy");
-    copy_btn.set_focusable(true);
-    copy_btn.set_halign(gtk4::Align::Start);
-
-    let copied_label = gtk4::Label::new(Some("Copied!"));
-    copied_label.add_css_class("math-copied");
-    copied_label.set_visible(false);
-
-    let copied_ref = copied_label.clone();
-    let pending_timer: std::rc::Rc<std::cell::Cell<Option<gtk4::glib::SourceId>>> =
-        std::rc::Rc::new(std::cell::Cell::new(None));
-    let timer_ref = std::rc::Rc::clone(&pending_timer);
-    copy_btn.connect_clicked(move |_| {
-        let mut cmd = std::process::Command::new("wl-copy");
-        cmd.arg(&result_copy);
-        match cmd.spawn() {
-            Ok(child) => nwg_common::launch::reap_child(child, "wl-copy".to_string()),
-            Err(_) => return, // wl-copy not available — skip "Copied!" feedback
-        }
-        // Cancel previous hide timer so repeated clicks reset the 2s window
-        if let Some(id) = timer_ref.take() {
-            id.remove();
-        }
-        copied_ref.set_visible(true);
-        let hide_ref = copied_ref.clone();
-        let timer_reset = std::rc::Rc::clone(&timer_ref);
-        let id = gtk4::glib::timeout_add_local_once(
-            std::time::Duration::from_secs(super::constants::COPIED_LABEL_TIMEOUT_SECS),
-            move || {
-                hide_ref.set_visible(false);
-                timer_reset.set(None);
-            },
-        );
-        timer_ref.set(Some(id));
-    });
-    row.append(&copy_btn);
-    vbox.append(row);
-    vbox.append(&copied_label);
-}
-
-fn format_result(value: f64) -> String {
+/// Formats an `f64` for display in the math result row. Handles four
+/// branches: snap-to-zero for FP noise, integer rendering for whole
+/// values inside the i64-safe range, scientific notation for very
+/// large or very small magnitudes, and trimmed decimal otherwise.
+pub(super) fn format_result(value: f64) -> String {
     // Snap to zero at display precision (6 decimal places) so
     // expressions like sin(pi) show "0" instead of "1.2e-16"
     if value.abs() < 0.5e-6 {

--- a/src/ui/math_widget.rs
+++ b/src/ui/math_widget.rs
@@ -1,0 +1,133 @@
+//! GTK widget for inline math results in the file-search well.
+//!
+//! Builds a `Box` containing the rendered `expr = result` line plus a
+//! "Copy" button that shells out to `wl-copy` on click. The pure
+//! evaluator + `format_result` lives in [`super::math`]; this module
+//! is the GTK / clipboard / keyboard-navigation half.
+//!
+//! Styling (font size, padding, border radius, colors) is in
+//! `assets/drawer.css` under the `.math-result` / `.math-copy` rules.
+//! No runtime CSS injection — the embedded stylesheet is loaded once at
+//! drawer activation.
+use super::constants;
+use super::math::{MathResult, eval_expression};
+use gtk4::prelude::*;
+
+/// Builds an inline math result widget for the search well.
+/// Returns `None` if the phrase isn't a math expression.
+pub fn build_math_result(phrase: &str) -> Option<gtk4::Box> {
+    let (label_text, result_str) = match eval_expression(phrase) {
+        MathResult::Value(val) => {
+            let r = super::math::format_result(val);
+            (format!("{} = {}", phrase, r), Some(r))
+        }
+        MathResult::Error(msg) => (format!("{} — {}", phrase, msg), None),
+        MathResult::NotMath => return None,
+    };
+
+    let vbox = gtk4::Box::new(gtk4::Orientation::Vertical, constants::MATH_VBOX_SPACING);
+    vbox.set_halign(gtk4::Align::Center);
+    vbox.set_margin_top(constants::STATUS_AREA_VERTICAL_MARGIN);
+    vbox.set_margin_bottom(constants::STATUS_AREA_VERTICAL_MARGIN);
+    // Don't set focusable(false) — the capture-phase key controller needs
+    // the container to participate in event dispatch for arrow key navigation.
+
+    let row = gtk4::Box::new(gtk4::Orientation::Horizontal, 0);
+    row.set_halign(gtk4::Align::Center);
+
+    let label = gtk4::Label::new(Some(&label_text));
+    label.add_css_class("math-result");
+    label.set_halign(gtk4::Align::End);
+    label.set_focusable(false);
+    row.append(&label);
+
+    if let Some(result_copy) = result_str {
+        append_copy_button(&row, &vbox, result_copy);
+    } else {
+        vbox.append(&row);
+    }
+
+    install_keyboard_nav(&vbox);
+    Some(vbox)
+}
+
+/// Capture-phase key controller on the math vbox — fires before GTK's
+/// focus machinery processes arrow keys on the child Copy button. Same
+/// pattern as `install_grid_nav` on FlowBoxes (see `super::navigation`).
+fn install_keyboard_nav(vbox: &gtk4::Box) {
+    let vbox_weak = vbox.downgrade();
+    let nav_ctrl = gtk4::EventControllerKey::new();
+    nav_ctrl.set_propagation_phase(gtk4::PropagationPhase::Capture);
+    nav_ctrl.connect_key_pressed(move |_, keyval, _, _| {
+        let Some(vbox_ref) = vbox_weak.upgrade() else {
+            return gtk4::glib::Propagation::Proceed;
+        };
+        match keyval {
+            gtk4::gdk::Key::Down | gtk4::gdk::Key::Tab => {
+                if super::navigation::focus_next_sibling(&vbox_ref) {
+                    gtk4::glib::Propagation::Stop
+                } else {
+                    gtk4::glib::Propagation::Proceed
+                }
+            }
+            gtk4::gdk::Key::Up | gtk4::gdk::Key::ISO_Left_Tab => {
+                if super::navigation::focus_prev_sibling(&vbox_ref) {
+                    gtk4::glib::Propagation::Stop
+                } else {
+                    gtk4::glib::Propagation::Proceed
+                }
+            }
+            _ => gtk4::glib::Propagation::Proceed,
+        }
+    });
+    vbox.add_controller(nav_ctrl);
+}
+
+/// Appends a copy button and "Copied!" label to the math result row.
+/// Copies the result to clipboard via wl-copy on click, with a 2-second
+/// confirmation label that resets on repeated clicks.
+fn append_copy_button(row: &gtk4::Box, vbox: &gtk4::Box, result_copy: String) {
+    let sep = gtk4::Separator::new(gtk4::Orientation::Vertical);
+    sep.add_css_class("math-divider");
+    row.append(&sep);
+
+    let copy_btn = gtk4::Button::with_label("Copy");
+    copy_btn.add_css_class("math-copy");
+    copy_btn.set_focusable(true);
+    copy_btn.set_halign(gtk4::Align::Start);
+
+    let copied_label = gtk4::Label::new(Some("Copied!"));
+    copied_label.add_css_class("math-copied");
+    copied_label.set_visible(false);
+
+    let copied_ref = copied_label.clone();
+    let pending_timer: std::rc::Rc<std::cell::Cell<Option<gtk4::glib::SourceId>>> =
+        std::rc::Rc::new(std::cell::Cell::new(None));
+    let timer_ref = std::rc::Rc::clone(&pending_timer);
+    copy_btn.connect_clicked(move |_| {
+        let mut cmd = std::process::Command::new("wl-copy");
+        cmd.arg(&result_copy);
+        match cmd.spawn() {
+            Ok(child) => nwg_common::launch::reap_child(child, "wl-copy".to_string()),
+            Err(_) => return, // wl-copy not available — skip "Copied!" feedback
+        }
+        // Cancel previous hide timer so repeated clicks reset the 2s window
+        if let Some(id) = timer_ref.take() {
+            id.remove();
+        }
+        copied_ref.set_visible(true);
+        let hide_ref = copied_ref.clone();
+        let timer_reset = std::rc::Rc::clone(&timer_ref);
+        let id = gtk4::glib::timeout_add_local_once(
+            std::time::Duration::from_secs(constants::COPIED_LABEL_TIMEOUT_SECS),
+            move || {
+                hide_ref.set_visible(false);
+                timer_reset.set(None);
+            },
+        );
+        timer_ref.set(Some(id));
+    });
+    row.append(&copy_btn);
+    vbox.append(row);
+    vbox.append(&copied_label);
+}

--- a/src/ui/math_widget.rs
+++ b/src/ui/math_widget.rs
@@ -106,7 +106,9 @@ fn append_copy_button(row: &gtk4::Box, vbox: &gtk4::Box, result_copy: String) {
     let timer_ref = std::rc::Rc::clone(&pending_timer);
     copy_btn.connect_clicked(move |_| {
         let mut cmd = std::process::Command::new("wl-copy");
-        cmd.arg(&result_copy);
+        // `--` ends wl-copy's option parsing so negative results (e.g. `-5`,
+        // `-3.14`) aren't mistaken for unknown flags.
+        cmd.arg("--").arg(&result_copy);
         match cmd.spawn() {
             Ok(child) => nwg_common::launch::reap_child(child, "wl-copy".to_string()),
             Err(e) => {

--- a/src/ui/math_widget.rs
+++ b/src/ui/math_widget.rs
@@ -32,7 +32,7 @@ pub fn build_math_result(phrase: &str) -> Option<gtk4::Box> {
     // Don't set focusable(false) — the capture-phase key controller needs
     // the container to participate in event dispatch for arrow key navigation.
 
-    let row = gtk4::Box::new(gtk4::Orientation::Horizontal, 0);
+    let row = gtk4::Box::new(gtk4::Orientation::Horizontal, constants::MATH_ROW_SPACING);
     row.set_halign(gtk4::Align::Center);
 
     let label = gtk4::Label::new(Some(&label_text));
@@ -109,7 +109,13 @@ fn append_copy_button(row: &gtk4::Box, vbox: &gtk4::Box, result_copy: String) {
         cmd.arg(&result_copy);
         match cmd.spawn() {
             Ok(child) => nwg_common::launch::reap_child(child, "wl-copy".to_string()),
-            Err(_) => return, // wl-copy not available — skip "Copied!" feedback
+            Err(e) => {
+                log::warn!(
+                    "Failed to spawn wl-copy: {} (clipboard copy unavailable)",
+                    e
+                );
+                return;
+            }
         }
         // Cancel previous hide timer so repeated clicks reset the 2s window
         if let Some(id) = timer_ref.take() {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -3,6 +3,7 @@ pub mod categories;
 pub mod constants;
 pub mod file_search;
 pub mod math;
+pub mod math_widget;
 pub mod navigation;
 pub mod power_bar;
 pub mod search;

--- a/src/ui/well_builder.rs
+++ b/src/ui/well_builder.rs
@@ -66,7 +66,7 @@ pub fn build_search_results(ctx: &WellContext, phrase: &str) {
     ctx.pinned_box.set_visible(false);
 
     // Inline math result (e.g. "1+1 = 2") shown above app results
-    if let Some(math_widget) = ui::math::build_math_result(phrase) {
+    if let Some(math_widget) = ui::math_widget::build_math_result(phrase) {
         ctx.well.append(&math_widget);
     }
 


### PR DESCRIPTION
## Summary

Closes #35. Penultimate Wave 3 architectural cleanup.

`ui/math.rs` was 493 lines holding three separable concerns; this PR splits them along the natural boundary so the pure evaluator stays a tight, GTK-free, fully-testable module.

## Layout after

| File | Lines | Purpose |
|---|---|---|
| `src/ui/math.rs` | 493 → **358** | `MathResult` + `DrawerOpsFactory` + `eval_expression` + `format_result` + 30 unit tests. Zero GTK deps. |
| `src/ui/math_widget.rs` | new, **133** | `build_math_result` + `append_copy_button` + keyboard-nav controller. The GTK / clipboard half. |
| `src/assets/drawer.css` | +34 | New `.math-result` / `.math-divider` / `.math-copy` / `.math-copied` rules (values baked in alongside an explanatory section comment). |
| `src/ui/constants.rs` | -8 | Five CSS-only constants removed (`MATH_FONT_SIZE`, `MATH_SPACING`, `MATH_BORDER_RADIUS`, `MATH_BUTTON_PADDING_V`, `MATH_BUTTON_PADDING_H`). `MATH_VBOX_SPACING` kept — still used by Rust-side vbox construction. |

## What's gone

The `static CSS_LOADED: std::sync::Once` block that runtime-injected math CSS via `format!("{ ... }", fs = MATH_FONT_SIZE, ... )` is deleted. The math styles now load with the rest of the embedded stylesheet at activate time, matching the pattern used everywhere else in the codebase.

## Note on the constants

Per CLAUDE.md "all UI dimensions in `ui/constants.rs`," I considered keeping the 5 values as `pub const`s. But after the split they're consumed only by the static stylesheet, not by Rust — the only way to keep them without `#[allow(dead_code)]` (also forbidden by CLAUDE.md) was to keep the dynamic injection, which the issue body explicitly wanted removed. Resolution: hardcode the values in `drawer.css` with an inline comment pointing at issue #35 for archaeology.

## Acceptance from #35

- [x] `ui/math.rs` ≤ 250 lines for the non-test code (133 lines of evaluator + format + DrawerOpsFactory; 358 total with the comprehensive test module the issue says to keep)
- [x] new `ui/math_widget.rs` for builder + clipboard
- [x] math styles moved into `assets/drawer.css`
- [x] `Once` block removed

## Test plan

- [x] `cargo build` clean
- [x] `make lint` clean (fmt + clippy + test + deny + audit)
- [x] All 82 tests pass — every math test stays with the evaluator
- [x] Visual smoke test welcome (math-result row should render identically — same CSS values, just delivered from the static stylesheet now)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an inline math result UI with copy-to-clipboard and transient “Copied!” confirmation.
  * Keyboard focus handling to move between results via arrow/tab keys.

* **Bug Fixes**
  * Copy button now correctly copies negative values.

* **Style**
  * Centralized styling for math result rows, dividers, and copy controls in the main stylesheet.

* **Documentation**
  * Updated module layout docs to reflect the new inline math widget organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->