### PR TITLE
Move XDG user-dir helpers out of state.rs (Wave 3, #38)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ src/
 ├── listeners/
 │   └── commands.rs      # WindowOp state machine + GTK command handler + tests
 ├── watcher.rs           # inotify watcher thread (.desktop + pin-file)
+├── xdg_dirs.rs          # ~/.config/user-dirs.dirs parser → name→path map
 └── ui/
     ├── navigation.rs     # install_grid_nav — capture-phase arrow-key
     │                     # traversal across FlowBox grids (app grid,

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod power_bar_detect;
 mod state;
 mod ui;
 mod watcher;
+mod xdg_dirs;
 
 use crate::config::DrawerConfig;
 use clap::Parser;

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,4 @@
-use crate::xdg_dirs;
+use crate::xdg_dirs::{self, XdgDirBucket};
 use nwg_common::compositor::Compositor;
 use nwg_common::desktop::entry::DesktopEntry;
 use std::collections::HashMap;
@@ -63,7 +63,7 @@ pub struct DrawerState {
     /// App directories for icon/exec resolution.
     pub app_dirs: Vec<PathBuf>,
     /// XDG user directory map (e.g. "documents" → "/home/user/Documents").
-    pub user_dirs: HashMap<String, PathBuf>,
+    pub user_dirs: HashMap<XdgDirBucket, PathBuf>,
     /// Directories excluded from file search.
     pub exclusions: Vec<String>,
     /// Custom file associations (pattern → command).

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,3 +1,4 @@
+use crate::xdg_dirs;
 use nwg_common::compositor::Compositor;
 use nwg_common::desktop::entry::DesktopEntry;
 use std::collections::HashMap;
@@ -84,7 +85,7 @@ impl DrawerState {
             apps: AppRegistry::new(),
             pinned: Vec::new(),
             app_dirs,
-            user_dirs: map_xdg_user_dirs(),
+            user_dirs: xdg_dirs::map_xdg_user_dirs(),
             exclusions: Vec::new(),
             preferred_apps: HashMap::new(),
             gtk_theme_prefix: String::new(),
@@ -93,49 +94,4 @@ impl DrawerState {
             active_search: String::new(),
         }
     }
-}
-
-/// Maps XDG user directory names to paths.
-fn map_xdg_user_dirs() -> HashMap<String, PathBuf> {
-    let mut result = HashMap::new();
-    let home = std::env::var("HOME").unwrap_or_default();
-
-    result.insert("home".into(), PathBuf::from(&home));
-    result.insert("documents".into(), PathBuf::from(&home).join("Documents"));
-    result.insert("downloads".into(), PathBuf::from(&home).join("Downloads"));
-    result.insert("music".into(), PathBuf::from(&home).join("Music"));
-    result.insert("pictures".into(), PathBuf::from(&home).join("Pictures"));
-    result.insert("videos".into(), PathBuf::from(&home).join("Videos"));
-
-    let config_home =
-        std::env::var("XDG_CONFIG_HOME").unwrap_or_else(|_| format!("{}/.config", home));
-    let user_dirs_file = PathBuf::from(&config_home).join("user-dirs.dirs");
-
-    if let Ok(content) = std::fs::read_to_string(&user_dirs_file) {
-        for line in content.lines() {
-            let line = line.trim();
-            if let Some(val) = parse_user_dir_line(line, &home) {
-                if line.starts_with("XDG_DOCUMENTS_DIR") {
-                    result.insert("documents".into(), val);
-                } else if line.starts_with("XDG_DOWNLOAD_DIR") {
-                    result.insert("downloads".into(), val);
-                } else if line.starts_with("XDG_MUSIC_DIR") {
-                    result.insert("music".into(), val);
-                } else if line.starts_with("XDG_PICTURES_DIR") {
-                    result.insert("pictures".into(), val);
-                } else if line.starts_with("XDG_VIDEOS_DIR") {
-                    result.insert("videos".into(), val);
-                }
-            }
-        }
-    }
-
-    result
-}
-
-fn parse_user_dir_line(line: &str, home: &str) -> Option<PathBuf> {
-    let (_, value) = line.split_once('=')?;
-    let value = value.trim().trim_matches('"');
-    let expanded = value.replace("$HOME", home);
-    Some(PathBuf::from(expanded))
 }

--- a/src/ui/file_search.rs
+++ b/src/ui/file_search.rs
@@ -22,8 +22,10 @@ pub fn search_files(
 
     let mut all_results: Vec<(String, std::path::PathBuf, bool)> = Vec::new();
 
-    for (dir_name, dir_path) in &user_dirs {
-        if dir_name == "home" || !dir_path.exists() {
+    for (bucket, dir_path) in &user_dirs {
+        // Skip $HOME itself — walking the entire home tree is what every
+        // other XDG dir is a more-targeted slice of.
+        if *bucket == crate::xdg_dirs::XdgDirBucket::Home || !dir_path.exists() {
             continue;
         }
         let remaining = config.fs_max_results.saturating_sub(all_results.len());

--- a/src/xdg_dirs.rs
+++ b/src/xdg_dirs.rs
@@ -1,0 +1,151 @@
+//! XDG user-directory resolution for file search.
+//!
+//! Reads `~/.config/user-dirs.dirs` (or `$XDG_CONFIG_HOME/user-dirs.dirs`)
+//! and returns a `name → PathBuf` map covering `home`, `documents`,
+//! `downloads`, `music`, `pictures`, `videos`. Used by `file_search` to
+//! enumerate the search roots.
+//!
+//! Defaults are seeded from `$HOME/<DefaultName>` so the drawer still
+//! works on systems where the user-dirs.dirs file is missing or
+//! malformed; entries from the file override the defaults.
+//!
+//! Extracted from `state.rs` (issue #38) so the parser is unit-testable
+//! without constructing a `DrawerState` and so `state.rs` can stay
+//! data-only.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+/// Maps XDG user directory names to paths. Defaults to `$HOME/<Name>`
+/// for each well-known directory, then overrides from the entries
+/// found in `~/.config/user-dirs.dirs`.
+pub(crate) fn map_xdg_user_dirs() -> HashMap<String, PathBuf> {
+    let mut result = HashMap::new();
+    let home = std::env::var("HOME").unwrap_or_default();
+
+    result.insert("home".into(), PathBuf::from(&home));
+    result.insert("documents".into(), PathBuf::from(&home).join("Documents"));
+    result.insert("downloads".into(), PathBuf::from(&home).join("Downloads"));
+    result.insert("music".into(), PathBuf::from(&home).join("Music"));
+    result.insert("pictures".into(), PathBuf::from(&home).join("Pictures"));
+    result.insert("videos".into(), PathBuf::from(&home).join("Videos"));
+
+    let config_home =
+        std::env::var("XDG_CONFIG_HOME").unwrap_or_else(|_| format!("{}/.config", home));
+    let user_dirs_file = PathBuf::from(&config_home).join("user-dirs.dirs");
+
+    if let Ok(content) = std::fs::read_to_string(&user_dirs_file) {
+        for line in content.lines() {
+            let line = line.trim();
+            // Skip blanks and comments without logging — those are normal.
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            let key = match line.split_once('=').map(|(k, _)| k) {
+                Some(k) => k,
+                None => {
+                    log::debug!("Skipping malformed user-dirs.dirs line (no '='): {}", line);
+                    continue;
+                }
+            };
+            // The XDG keys we care about. Anything else (e.g.
+            // XDG_TEMPLATES_DIR, XDG_PUBLICSHARE_DIR) is silently
+            // ignored — the drawer doesn't search those by default.
+            let bucket = match key {
+                "XDG_DOCUMENTS_DIR" => "documents",
+                "XDG_DOWNLOAD_DIR" => "downloads",
+                "XDG_MUSIC_DIR" => "music",
+                "XDG_PICTURES_DIR" => "pictures",
+                "XDG_VIDEOS_DIR" => "videos",
+                _ => continue,
+            };
+            match parse_user_dir_line(line, &home) {
+                Some(val) => {
+                    result.insert(bucket.into(), val);
+                }
+                None => {
+                    log::debug!(
+                        "Skipping unparseable user-dirs.dirs line for {}: {}",
+                        key,
+                        line
+                    );
+                }
+            }
+        }
+    }
+
+    result
+}
+
+/// Parses a single `XDG_FOO_DIR="$HOME/Bar"` style line. Returns the
+/// resolved `PathBuf` on success, or `None` if the line lacks `=` or
+/// the value is empty after trimming quotes.
+fn parse_user_dir_line(line: &str, home: &str) -> Option<PathBuf> {
+    let (_, value) = line.split_once('=')?;
+    let value = value.trim().trim_matches('"');
+    if value.is_empty() {
+        return None;
+    }
+    let expanded = value.replace("$HOME", home);
+    Some(PathBuf::from(expanded))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_quoted_value_with_home_expansion() {
+        assert_eq!(
+            parse_user_dir_line("XDG_DOCUMENTS_DIR=\"$HOME/Docs\"", "/home/u"),
+            Some(PathBuf::from("/home/u/Docs"))
+        );
+    }
+
+    #[test]
+    fn parses_unquoted_value() {
+        assert_eq!(
+            parse_user_dir_line("XDG_DOWNLOAD_DIR=$HOME/Downloads", "/home/u"),
+            Some(PathBuf::from("/home/u/Downloads"))
+        );
+    }
+
+    #[test]
+    fn line_without_equals_returns_none() {
+        assert!(parse_user_dir_line("XDG_DOCUMENTS_DIR", "/home/u").is_none());
+    }
+
+    #[test]
+    fn empty_value_returns_none() {
+        assert!(parse_user_dir_line("XDG_DOCUMENTS_DIR=\"\"", "/home/u").is_none());
+        assert!(parse_user_dir_line("XDG_DOCUMENTS_DIR=", "/home/u").is_none());
+    }
+
+    #[test]
+    fn home_substitution_works_anywhere_in_path() {
+        // Documented behavior: `$HOME` is replaced wherever it appears,
+        // not just as a prefix. Pin this so a future "only-prefix"
+        // optimization doesn't silently change semantics.
+        assert_eq!(
+            parse_user_dir_line("XDG_DOCUMENTS_DIR=\"/mnt/$HOME/Docs\"", "/home/u"),
+            Some(PathBuf::from("/mnt//home/u/Docs"))
+        );
+    }
+
+    #[test]
+    fn handles_path_without_home_var() {
+        // Absolute path with no $HOME reference passes through.
+        assert_eq!(
+            parse_user_dir_line("XDG_DOCUMENTS_DIR=\"/srv/shared/docs\"", "/home/u"),
+            Some(PathBuf::from("/srv/shared/docs"))
+        );
+    }
+
+    #[test]
+    fn whitespace_around_value_is_trimmed() {
+        assert_eq!(
+            parse_user_dir_line("XDG_PICTURES_DIR=  \"$HOME/Pics\"  ", "/home/u"),
+            Some(PathBuf::from("/home/u/Pics"))
+        );
+    }
+}

--- a/src/xdg_dirs.rs
+++ b/src/xdg_dirs.rs
@@ -16,65 +16,112 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-/// Maps XDG user directory names to paths. Defaults to `$HOME/<Name>`
+/// Well-known XDG user-directory categories the drawer searches in.
+///
+/// Replaces the previous stringly-typed bucket keys (`"documents"`,
+/// `"downloads"`, …) per CLAUDE.md "enums over strings." Other XDG
+/// keys (`XDG_TEMPLATES_DIR`, `XDG_PUBLICSHARE_DIR`) are not represented
+/// — the drawer doesn't search those by default.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum XdgDirBucket {
+    /// `$HOME` itself. Excluded from the file-search walk root list
+    /// (would walk the entire home tree); kept in the map so callers
+    /// that need an explicit home reference can look it up.
+    Home,
+    Documents,
+    Downloads,
+    Music,
+    Pictures,
+    Videos,
+}
+
+/// Maps XDG user directory buckets to paths. Defaults to `$HOME/<Name>`
 /// for each well-known directory, then overrides from the entries
 /// found in `~/.config/user-dirs.dirs`.
-pub(crate) fn map_xdg_user_dirs() -> HashMap<String, PathBuf> {
+///
+/// Returns an empty map if `$HOME` is unset or empty — without it,
+/// every default would be a relative path resolved against the
+/// process CWD, which would silently redirect file search.
+pub(crate) fn map_xdg_user_dirs() -> HashMap<XdgDirBucket, PathBuf> {
     let mut result = HashMap::new();
-    let home = std::env::var("HOME").unwrap_or_default();
+    let home = match std::env::var("HOME") {
+        Ok(h) if !h.is_empty() => h,
+        _ => {
+            log::warn!("$HOME is unset or empty; XDG user dirs unavailable for file search");
+            return result;
+        }
+    };
 
-    result.insert("home".into(), PathBuf::from(&home));
-    result.insert("documents".into(), PathBuf::from(&home).join("Documents"));
-    result.insert("downloads".into(), PathBuf::from(&home).join("Downloads"));
-    result.insert("music".into(), PathBuf::from(&home).join("Music"));
-    result.insert("pictures".into(), PathBuf::from(&home).join("Pictures"));
-    result.insert("videos".into(), PathBuf::from(&home).join("Videos"));
+    result.insert(XdgDirBucket::Home, PathBuf::from(&home));
+    result.insert(
+        XdgDirBucket::Documents,
+        PathBuf::from(&home).join("Documents"),
+    );
+    result.insert(
+        XdgDirBucket::Downloads,
+        PathBuf::from(&home).join("Downloads"),
+    );
+    result.insert(XdgDirBucket::Music, PathBuf::from(&home).join("Music"));
+    result.insert(
+        XdgDirBucket::Pictures,
+        PathBuf::from(&home).join("Pictures"),
+    );
+    result.insert(XdgDirBucket::Videos, PathBuf::from(&home).join("Videos"));
 
     let config_home =
         std::env::var("XDG_CONFIG_HOME").unwrap_or_else(|_| format!("{}/.config", home));
     let user_dirs_file = PathBuf::from(&config_home).join("user-dirs.dirs");
 
-    if let Ok(content) = std::fs::read_to_string(&user_dirs_file) {
-        for line in content.lines() {
-            let line = line.trim();
-            // Skip blanks and comments without logging — those are normal.
-            if line.is_empty() || line.starts_with('#') {
-                continue;
-            }
-            let key = match line.split_once('=').map(|(k, _)| k) {
-                Some(k) => k,
-                None => {
-                    log::debug!("Skipping malformed user-dirs.dirs line (no '='): {}", line);
-                    continue;
-                }
-            };
-            // The XDG keys we care about. Anything else (e.g.
-            // XDG_TEMPLATES_DIR, XDG_PUBLICSHARE_DIR) is silently
-            // ignored — the drawer doesn't search those by default.
-            let bucket = match key {
-                "XDG_DOCUMENTS_DIR" => "documents",
-                "XDG_DOWNLOAD_DIR" => "downloads",
-                "XDG_MUSIC_DIR" => "music",
-                "XDG_PICTURES_DIR" => "pictures",
-                "XDG_VIDEOS_DIR" => "videos",
-                _ => continue,
-            };
-            match parse_user_dir_line(line, &home) {
-                Some(val) => {
-                    result.insert(bucket.into(), val);
-                }
-                None => {
-                    log::debug!(
-                        "Skipping unparseable user-dirs.dirs line for {}: {}",
-                        key,
-                        line
-                    );
-                }
-            }
-        }
+    match std::fs::read_to_string(&user_dirs_file) {
+        Ok(content) => apply_overrides(&mut result, &content, &home),
+        // NotFound is the common "user never ran xdg-user-dirs-update" case;
+        // defaults already cover those entries. Any other I/O error is worth
+        // surfacing at debug.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => log::debug!("Failed to read {}: {}", user_dirs_file.display(), e),
     }
 
     result
+}
+
+/// Applies user-dirs.dirs overrides to an already-defaulted bucket map.
+fn apply_overrides(result: &mut HashMap<XdgDirBucket, PathBuf>, content: &str, home: &str) {
+    for line in content.lines() {
+        let line = line.trim();
+        // Skip blanks and comments without logging — those are normal.
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let key = match line.split_once('=').map(|(k, _)| k) {
+            Some(k) => k,
+            None => {
+                log::debug!("Skipping malformed user-dirs.dirs line (no '='): {}", line);
+                continue;
+            }
+        };
+        let bucket = match key {
+            "XDG_DOCUMENTS_DIR" => XdgDirBucket::Documents,
+            "XDG_DOWNLOAD_DIR" => XdgDirBucket::Downloads,
+            "XDG_MUSIC_DIR" => XdgDirBucket::Music,
+            "XDG_PICTURES_DIR" => XdgDirBucket::Pictures,
+            "XDG_VIDEOS_DIR" => XdgDirBucket::Videos,
+            // Anything else (e.g. XDG_TEMPLATES_DIR, XDG_PUBLICSHARE_DIR)
+            // is silently ignored — the drawer doesn't search those.
+            _ => continue,
+        };
+        match parse_user_dir_line(line, home) {
+            Some(val) => {
+                result.insert(bucket, val);
+            }
+            None => {
+                log::debug!(
+                    "Skipping unparseable user-dirs.dirs line for {}: {}",
+                    key,
+                    line
+                );
+            }
+        }
+    }
 }
 
 /// Parses a single `XDG_FOO_DIR="$HOME/Bar"` style line. Returns the


### PR DESCRIPTION
## Summary

Closes #38. **Final Wave 3 architectural cleanup.** With this merged, Wave 3 is complete (5/5).

`state.rs` had ~40% of its bulk in one-shot XDG `~/.config/user-dirs.dirs` parsing — `map_xdg_user_dirs` + `parse_user_dir_line`. One-shot config load isn't state. Verified `nwg-common` has no upstream home for this (no XDG user-dirs handling anywhere in `nwg_common::config` or `nwg_common::desktop`), so going local: new `src/xdg_dirs.rs`.

## Layout after

| File | Lines | Purpose |
|---|---|---|
| `src/state.rs` | 112 → **98** | `DrawerState` / `AppRegistry` definitions only — data shape, no logic |
| `src/xdg_dirs.rs` | new, **157** | Parser + 7 unit tests |

## Behavioral cleanup while moving

Per the issue body's "fix while moving" instruction:

- **`parse_user_dir_line` now logs at `debug` on malformed input.** Two log sites: missing `=`, and unparseable value after a recognized XDG key. Comments and blanks are silently skipped — those are normal in the file format.
- **Empty value returns `None`.** `XDG_DIR=""` or `XDG_DIR=` previously produced a zero-length `PathBuf`, which would have inserted an empty path into the registry. Now those lines are skipped.
- **XDG-key dispatch collapses** from five `else if line.starts_with(...)` arms to one `match` on the parsed key.

Same behavior on the success path; only the error/edge cases were tightened.

## Tests

7 new pure-function tests cover:

- Quoted value with `$HOME` expansion
- Unquoted value
- Line without `=` returns `None`
- Empty value returns `None` (both `=""` and `=`)
- `$HOME` substitution works anywhere in the path (pinned, since this is a quirk of the implementation)
- Path with no `$HOME` reference passes through unchanged
- Whitespace around the value is trimmed

This combines the E-F1 acceptance ("new pure-function tests against the parser") with the move.

## Acceptance from #38

- [x] `state.rs` is data-only
- [x] Helpers in their own module (no upstream home in nwg-common — checked)
- [x] `parse_user_dir_line` logs malformed lines at `debug`
- [x] New pure-function tests against the parser

## Test plan

- [x] `cargo build` clean
- [x] `make lint` clean (fmt + clippy + test + deny + audit)
- [x] All 89 tests pass — 82 existing + 7 new

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for reading and applying XDG user directory overrides from user XDG config (e.g., custom Documents/Downloads/Pictures locations).

* **Refactor**
  * Directory path resolution moved into a dedicated component for cleaner organization and reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->