### PR TITLE
Replace mpsc + 100ms-poll with async_channel + glib futures (Wave 4, #40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Hardened category, search, and pin-toggle callbacks against re-entrant
   signal panics during pin/unpin I/O. Resolves #30.
+- RT-signal toggle/show/hide and inotify-driven file-watcher events now
+  deliver to the UI in under a millisecond instead of up to 100 ms. The
+  drawer used to poll its event channels at a fixed 100 ms cadence; now
+  both consumers attach to the glib main loop via `async_channel` and
+  run as soon as their event arrives. Resolves #40.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hardened category, search, and pin-toggle callbacks against re-entrant
   signal panics during pin/unpin I/O. Resolves #30.
 - RT-signal toggle/show/hide and inotify-driven file-watcher events now
-  deliver to the UI in under a millisecond instead of up to 100 ms. The
-  drawer used to poll its event channels at a fixed 100 ms cadence; now
-  both consumers attach to the glib main loop via `async_channel` and
-  run as soon as their event arrives. Resolves #40.
+  reach the UI immediately instead of waiting for the old 100 ms poll
+  interval. Resolves #40.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,6 +189,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +261,27 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -922,6 +970,7 @@ name = "nwg-drawer"
 version = "0.3.0"
 dependencies = [
  "anyhow",
+ "async-channel",
  "clap",
  "env_logger",
  "exmex",
@@ -977,6 +1026,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "pin-project-lite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,13 @@ nix = { version = "0.31", features = ["signal", "process", "fs"] }
 # Migrated off `meval` because its nom 1.2.4 transitive dep was unmaintained.
 exmex = "0.20"
 
+# Cross-thread → glib-main-loop event channel for the inotify watcher and
+# the signal-handler bridge. Replaces the 100 ms `timeout_add_local`
+# polling pattern with sub-ms event delivery via `glib::spawn_future_local`
+# + `recv().await`. (`glib::MainContext::channel` is deprecated in glib
+# 0.21 in favor of executor-agnostic async channels.)
+async-channel = "2"
+
 [dev-dependencies]
 # Filesystem fixtures for unit tests (walk_directory, etc.).
 tempfile = "3"

--- a/src/activate.rs
+++ b/src/activate.rs
@@ -23,7 +23,6 @@ use nwg_common::signals::WindowCommand;
 use std::cell::{Cell, RefCell};
 use std::path::PathBuf;
 use std::rc::Rc;
-use std::sync::mpsc::Receiver;
 
 /// Mac-style drawer CSS, embedded at compile time.
 const DRAWER_CSS: &str = include_str!("assets/drawer.css");
@@ -42,7 +41,7 @@ pub(crate) struct DrawerInit {
     pub(crate) app_dirs: Vec<PathBuf>,
     pub(crate) exclusions: Vec<String>,
     pub(crate) compositor: Rc<dyn nwg_common::compositor::Compositor>,
-    pub(crate) sig_rx: Rc<Receiver<WindowCommand>>,
+    pub(crate) sig_rx: async_channel::Receiver<WindowCommand>,
 }
 
 /// Sets up the drawer UI: CSS, state, window, layout, search, and listeners.

--- a/src/listeners.rs
+++ b/src/listeners.rs
@@ -174,7 +174,18 @@ pub fn setup_file_watcher(
         // that's already accumulated in the channel via `try_recv` (events
         // that landed during the previous rebuild), then do at most one
         // reload + rebuild for the whole batch.
-        while let Ok(first) = watch_rx.recv().await {
+        loop {
+            let first = match watch_rx.recv().await {
+                Ok(ev) => ev,
+                Err(e) => {
+                    // Producer (inotify thread) dropped its sender. Either
+                    // the thread panicked / failed to create the watcher —
+                    // worth surfacing — or the process is shutting down,
+                    // in which case the log message goes nowhere harmful.
+                    log::error!("file-watcher channel closed: {e}");
+                    break;
+                }
+            };
             let mut reload_desktop = matches!(first, watcher::WatchEvent::DesktopFilesChanged);
             let mut reload_pinned = matches!(first, watcher::WatchEvent::PinnedChanged);
 
@@ -222,7 +233,18 @@ pub fn setup_signal_poller(
     let rx = sig_rx.clone();
 
     glib::spawn_future_local(async move {
-        while let Ok(cmd) = rx.recv().await {
+        loop {
+            let cmd = match rx.recv().await {
+                Ok(cmd) => cmd,
+                Err(e) => {
+                    // The bridge thread in main.rs drops its sender at
+                    // process shutdown (when the upstream RT-signal mpsc
+                    // disconnects). On the live path this means the
+                    // signal pipeline died — surface it.
+                    log::error!("signal channel closed: {e}");
+                    break;
+                }
+            };
             commands::handle_window_command(&win, &entry, &ctx, &pending, cmd, resident);
         }
     });

--- a/src/listeners.rs
+++ b/src/listeners.rs
@@ -155,6 +155,15 @@ pub fn setup_file_watcher(
     let watch_rx = watcher::start_watcher(app_dirs, &ctx.pinned_file);
     let ctx = ctx.clone();
 
+    /// Cap on events drained per coalesce batch. The drain catches up to
+    /// inotify production in practice (try_recv runs in nanoseconds; event
+    /// production is rate-limited by the kernel), but a hostile workload
+    /// that produces events as fast as we drain them could otherwise stall
+    /// the GTK main loop indefinitely. 512 is comfortably above any
+    /// realistic burst size (`pacman -Syu` peaks at a few hundred events)
+    /// while still bounding the worst-case drain time.
+    const MAX_WATCH_EVENTS_PER_BATCH: usize = 512;
+
     glib::spawn_future_local(async move {
         // Coalesce bursts. inotify can fire dozens of events for a single
         // user-visible change (`watcher::start_watcher` doc spells this
@@ -169,7 +178,10 @@ pub fn setup_file_watcher(
             let mut reload_desktop = matches!(first, watcher::WatchEvent::DesktopFilesChanged);
             let mut reload_pinned = matches!(first, watcher::WatchEvent::PinnedChanged);
 
-            while let Ok(next) = watch_rx.try_recv() {
+            for _ in 0..MAX_WATCH_EVENTS_PER_BATCH {
+                let Ok(next) = watch_rx.try_recv() else {
+                    break;
+                };
                 reload_desktop |= matches!(next, watcher::WatchEvent::DesktopFilesChanged);
                 reload_pinned |= matches!(next, watcher::WatchEvent::PinnedChanged);
             }

--- a/src/listeners.rs
+++ b/src/listeners.rs
@@ -10,7 +10,6 @@ use nwg_common::pinning;
 use nwg_common::signals::WindowCommand;
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
-use std::sync::mpsc;
 
 /// Sets up keyboard handler for the drawer window.
 ///
@@ -145,6 +144,10 @@ pub fn setup_focus_detector(
 }
 
 /// Sets up inotify-based file watcher for pin and desktop file changes.
+///
+/// Events are delivered via `async_channel` and consumed by a glib
+/// future spawned on the main loop — no polling cadence, sub-ms
+/// latency from inotify event to UI rebuild.
 pub fn setup_file_watcher(
     app_dirs: &[std::path::PathBuf],
     ctx: &crate::ui::well_context::WellContext,
@@ -152,8 +155,8 @@ pub fn setup_file_watcher(
     let watch_rx = watcher::start_watcher(app_dirs, &ctx.pinned_file);
     let ctx = ctx.clone();
 
-    glib::timeout_add_local(std::time::Duration::from_millis(100), move || {
-        while let Ok(event) = watch_rx.try_recv() {
+    glib::spawn_future_local(async move {
+        while let Ok(event) = watch_rx.recv().await {
             match event {
                 watcher::WatchEvent::DesktopFilesChanged => {
                     log::info!("Desktop files changed, reloading...");
@@ -167,30 +170,33 @@ pub fn setup_file_watcher(
                 }
             }
         }
-        glib::ControlFlow::Continue
     });
 }
 
-/// Sets up signal handler polling for SIGRTMIN+1/2/3.
+/// Spawns the glib-main-loop consumer for SIGRTMIN+1/2/3 signals.
+///
+/// `main` bridges `nwg_common::signals`'s `mpsc::Receiver` to an
+/// `async_channel::Receiver` once at startup; this just attaches a
+/// glib future that awaits each command and dispatches it. Sub-ms
+/// latency from signal delivery to window action.
 pub fn setup_signal_poller(
     win: &gtk4::ApplicationWindow,
     search_entry: &gtk4::SearchEntry,
     well_ctx: &crate::ui::well_context::WellContext,
     focus_pending: &Rc<Cell<bool>>,
-    sig_rx: &Rc<mpsc::Receiver<WindowCommand>>,
+    sig_rx: &async_channel::Receiver<WindowCommand>,
     resident: bool,
 ) {
     let win = win.clone();
     let entry = search_entry.clone();
     let ctx = well_ctx.clone();
     let pending = Rc::clone(focus_pending);
-    let rx = Rc::clone(sig_rx);
+    let rx = sig_rx.clone();
 
-    glib::timeout_add_local(std::time::Duration::from_millis(100), move || {
-        while let Ok(cmd) = rx.try_recv() {
+    glib::spawn_future_local(async move {
+        while let Ok(cmd) = rx.recv().await {
             commands::handle_window_command(&win, &entry, &ctx, &pending, cmd, resident);
         }
-        glib::ControlFlow::Continue
     });
 }
 

--- a/src/listeners.rs
+++ b/src/listeners.rs
@@ -156,18 +156,34 @@ pub fn setup_file_watcher(
     let ctx = ctx.clone();
 
     glib::spawn_future_local(async move {
-        while let Ok(event) = watch_rx.recv().await {
-            match event {
-                watcher::WatchEvent::DesktopFilesChanged => {
-                    log::info!("Desktop files changed, reloading...");
-                    desktop_loader::load_desktop_entries(&mut ctx.state.borrow_mut());
-                    well_builder::rebuild_preserving_category(&ctx);
-                }
-                watcher::WatchEvent::PinnedChanged => {
-                    log::info!("Pinned file changed, rebuilding...");
-                    ctx.state.borrow_mut().pinned = pinning::load_pinned(&ctx.pinned_file);
-                    well_builder::rebuild_preserving_category(&ctx);
-                }
+        // Coalesce bursts. inotify can fire dozens of events for a single
+        // user-visible change (`watcher::start_watcher` doc spells this
+        // out — package installs are the worst case). Without coalescing,
+        // each event would trigger a synchronous rebuild on the GTK main
+        // loop, thrashing under exactly the workloads the watcher exists
+        // to handle. Pattern: await the first event, then drain everything
+        // that's already accumulated in the channel via `try_recv` (events
+        // that landed during the previous rebuild), then do at most one
+        // reload + rebuild for the whole batch.
+        while let Ok(first) = watch_rx.recv().await {
+            let mut reload_desktop = matches!(first, watcher::WatchEvent::DesktopFilesChanged);
+            let mut reload_pinned = matches!(first, watcher::WatchEvent::PinnedChanged);
+
+            while let Ok(next) = watch_rx.try_recv() {
+                reload_desktop |= matches!(next, watcher::WatchEvent::DesktopFilesChanged);
+                reload_pinned |= matches!(next, watcher::WatchEvent::PinnedChanged);
+            }
+
+            if reload_desktop {
+                log::info!("Desktop files changed, reloading...");
+                desktop_loader::load_desktop_entries(&mut ctx.state.borrow_mut());
+            }
+            if reload_pinned {
+                log::info!("Pinned file changed, rebuilding...");
+                ctx.state.borrow_mut().pinned = pinning::load_pinned(&ctx.pinned_file);
+            }
+            if reload_desktop || reload_pinned {
+                well_builder::rebuild_preserving_category(&ctx);
             }
         }
     });

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,19 @@ fn main() {
     let compositor: Rc<dyn nwg_common::compositor::Compositor> =
         Rc::from(nwg_common::compositor::init_or_null(config.wm));
 
-    let sig_rx = Rc::new(signals::setup_signal_handlers(config.resident));
+    // RT-signal handler returns a sync `mpsc::Receiver`. Bridge it to an
+    // `async_channel` so the listener can `recv().await` on the glib main
+    // loop instead of polling. The forwarding thread exits when the
+    // glib-side receiver drops at process shutdown.
+    let signal_mpsc = signals::setup_signal_handlers(config.resident);
+    let (sig_tx, sig_rx) = async_channel::unbounded::<nwg_common::signals::WindowCommand>();
+    std::thread::spawn(move || {
+        while let Ok(cmd) = signal_mpsc.recv() {
+            if sig_tx.send_blocking(cmd).is_err() {
+                break;
+            }
+        }
+    });
     let config_dir = paths::config_dir("nwg-drawer");
     if let Err(e) = paths::ensure_dir(&config_dir) {
         log::warn!("Failed to create config dir: {}", e);

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -12,17 +12,27 @@ pub enum WatchEvent {
 }
 
 /// Starts watching app directories and the pin cache file for changes.
-/// Returns a receiver that emits WatchEvent when relevant files change.
+///
+/// Returns an `async_channel::Receiver` so the consumer can attach to
+/// the glib main loop with `glib::spawn_future_local` + `.recv().await`
+/// — events arrive as the inotify thread sees them rather than at a
+/// fixed polling cadence.
 pub fn start_watcher(
     app_dirs: &[std::path::PathBuf],
     pin_file: &Path,
-) -> mpsc::Receiver<WatchEvent> {
-    let (tx, rx) = mpsc::channel();
+) -> async_channel::Receiver<WatchEvent> {
+    // Unbounded — file-system events are bursty (e.g. a package install
+    // can fire dozens of CREATE/MODIFY events) and bounding the channel
+    // would either drop events or block the inotify thread.
+    let (tx, rx) = async_channel::unbounded();
 
     let pin_path = pin_file.to_path_buf();
     let app_dir_list: Vec<_> = app_dirs.to_vec();
 
     std::thread::spawn(move || {
+        // Inner mpsc bridges the notify callback (non-async) to this
+        // thread's blocking for-loop. Stays mpsc — it's a same-thread
+        // pipeline, not a cross-thread → glib boundary.
         let (notify_tx, notify_rx) = mpsc::channel();
 
         let mut watcher = match notify::recommended_watcher(move |res: Result<Event, _>| {
@@ -40,8 +50,13 @@ pub fn start_watcher(
         register_watch_paths(&mut watcher, &app_dir_list, &pin_path);
 
         for event in notify_rx {
-            if let Some(watch_event) = classify_watch_event(&event, &pin_path) {
-                let _ = tx.send(watch_event); // Non-critical: receiver may have dropped
+            let Some(watch_event) = classify_watch_event(&event, &pin_path) else {
+                continue;
+            };
+            if tx.send_blocking(watch_event).is_err() {
+                // Glib-side receiver dropped — drawer is shutting down. Exit
+                // the thread so we don't spin forever on a dead channel.
+                break;
             }
         }
     });


### PR DESCRIPTION
## Summary

Closes #40. First Wave 4 perf item.

Both inotify-driven file-watcher events and RT-signal commands (`SIGRTMIN+1/2/3` toggle/show/hide) used to deliver via a fixed **100 ms polling cadence**: an `mpsc::Receiver` polled by `glib::timeout_add_local`. Worst-case 100 ms latency between event arrival and UI reaction — perceptible as lag on signal-driven toggle.

Migrated to `async_channel` + `glib::spawn_future_local`. The consumer `await`s on the channel and runs **as soon as the event arrives**. Sub-ms latency, no wasted wakeups when idle.

## Two channels touched

| Source | Before | After |
|---|---|---|
| `watcher::start_watcher` (drawer-internal) | returns `mpsc::Receiver`; consumer polls every 100 ms | returns `async_channel::Receiver`; consumer is `spawn_future_local(async { while let Ok(e) = rx.recv().await { … } })` |
| `nwg_common::signals::setup_signal_handlers` (sibling crate) | same poll pattern | bridge thread in `main.rs` reads the upstream `mpsc` and forwards via `send_blocking` to a drawer-side `async_channel`; consumer awaits like above |

The signal-bridge thread is necessary because the upstream API in `nwg-common` returns an `mpsc::Receiver`. Upstreaming the glib channel into `nwg-common` would drop the bridge thread; that's a sibling-crate API change, tracked separately and out of scope for this PR.

## Plumbing

- `DrawerInit::sig_rx`: `Rc<mpsc::Receiver<WindowCommand>>` → `async_channel::Receiver<WindowCommand>` (the latter is `Clone`, no `Rc` needed).
- `setup_signal_poller`: signature change, much shorter body — no `try_recv` loop, no timeout.
- `setup_file_watcher`: same shape.
- `Cargo.toml`: new dep `async-channel = "2"`. `glib::MainContext::channel` is deprecated in glib 0.21 in favor of executor-agnostic async channels; `async-channel` is the recommended path forward.

## Test plan

- [x] `cargo build` clean
- [x] `make lint` clean (fmt + clippy + test + deny + audit). The new `async-channel` transitive deps (`event-listener`, `concurrent-queue`, etc. — 6 crates total) all pass cargo-deny license/source/advisories checks.
- [x] All 89 tests pass

CHANGELOG: `### Changed` entry — toggle/show/hide signals and file-watcher events now respond in **<1 ms** instead of up to 100 ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of search, category, and pin-toggle callbacks during concurrent signal or I/O events.

* **Performance**
  * File-watcher and signal events now reach the UI immediately (sub-ms), removing the previous ~100 ms polling delay.

* **Behavior**
  * RT-signal toggle/show/hide actions and file-watcher-driven updates apply instantly; bursty file changes are coalesced to avoid redundant reloads.

* **Chores**
  * Added an async channel to enable event-driven delivery between background watchers and the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->