### PR TITLE
Move file-search walk off the GTK main thread (Wave 4, #39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RT-signal toggle/show/hide and inotify-driven file-watcher events now
   reach the UI immediately instead of waiting for the old 100 ms poll
   interval. Resolves #40.
+- File search no longer blocks the UI during typing. Each keystroke
+  used to walk every XDG user directory synchronously on the GTK main
+  thread, freezing the search bar for hundreds of milliseconds (or
+  multiple seconds against a heavy `~/Downloads`). The walk now
+  debounces 150 ms after the last keystroke and runs on a worker
+  thread; app-name results and the math evaluator stay instant.
+  Resolves #39.
 
 ### Fixed
 

--- a/src/activate.rs
+++ b/src/activate.rs
@@ -159,6 +159,18 @@ pub(crate) fn activate_drawer(app: &gtk4::Application, init: &DrawerInit) {
     well.set_margin_top(ui::constants::CONTENT_TOP_MARGIN);
     scrolled.set_child(Some(&well));
 
+    // Async file-search dispatcher. Spawns a single long-running consumer
+    // future on the main loop that receives walked results from worker
+    // threads and applies them to `well`. Per-keystroke `dispatch` calls
+    // bump a generation counter so stale workers get their results dropped.
+    let file_search = Rc::new(ui::file_search::FileSearchDispatcher::new(
+        Rc::clone(&config),
+        well.clone(),
+        status_label.clone(),
+        Rc::clone(&state),
+        Rc::clone(&on_launch),
+    ));
+
     // Shared context for well/category/search builders
     let well_ctx = ui::well_context::WellContext {
         well: well.clone(),
@@ -169,6 +181,7 @@ pub(crate) fn activate_drawer(app: &gtk4::Application, init: &DrawerInit) {
         on_launch: Rc::clone(&on_launch),
         status_label: status_label.clone(),
         search_entry: search_entry.clone(),
+        file_search,
     };
 
     // Categories (above scroll, fixed)

--- a/src/ui/categories.rs
+++ b/src/ui/categories.rs
@@ -101,6 +101,10 @@ fn create_category_button(
 /// Builds the well content filtered to a specific category.
 /// Public so the rebuild callback can restore the active filter after unpin.
 pub fn apply_category_filter(ctx: &WellContext, category_ids: &[String]) {
+    // Drop any in-flight file-search worker so its results don't land
+    // on the now-category-filtered well.
+    ctx.file_search.invalidate();
+
     while let Some(child) = ctx.well.first_child() {
         ctx.well.remove(&child);
     }

--- a/src/ui/file_search.rs
+++ b/src/ui/file_search.rs
@@ -1,53 +1,212 @@
 use super::constants;
 use crate::config::DrawerConfig;
 use crate::state::DrawerState;
+use crate::xdg_dirs::XdgDirBucket;
+use gtk4::glib;
 use gtk4::prelude::*;
-use std::cell::RefCell;
-use std::path::Path;
+use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
-/// Performs file search across XDG user directories.
-/// Returns a Box with a clean columnar list: icon | filename | path
-pub fn search_files(
+/// Debounce window after the last keystroke before kicking off the
+/// file-system walk. Long enough that a fast typist's bursts produce
+/// one walk per phrase rather than per character; short enough that
+/// the results feel prompt for a finished phrase.
+const FILE_SEARCH_DEBOUNCE_MS: u64 = 150;
+
+/// Async file-search dispatcher, owned by `WellContext`.
+///
+/// Each `dispatch` call:
+/// - Increments the generation counter so any in-flight worker's
+///   results can be detected as stale at the consumer.
+/// - Cancels any pending debounce timeout.
+/// - Schedules a `FILE_SEARCH_DEBOUNCE_MS` timeout that, on fire,
+///   spawns an OS thread to run `walk_for_search` and ship results
+///   back via `async_channel`.
+///
+/// A single consumer future on the GTK main loop receives
+/// `(generation, rows)` results, drops them if the generation has
+/// moved (user typed since), and otherwise appends the divider +
+/// results widget to the well.
+pub struct FileSearchDispatcher {
+    generation: Rc<Cell<u64>>,
+    pending_debounce: Cell<Option<glib::SourceId>>,
+    result_tx: async_channel::Sender<(u64, Vec<FileSearchRow>)>,
+    config: Rc<DrawerConfig>,
+}
+
+impl FileSearchDispatcher {
+    /// Constructs the dispatcher and spawns the long-running result
+    /// consumer future. The consumer captures the well + supporting
+    /// widgets it needs to render results; `state` and `on_launch` are
+    /// only used at result-render time, never moved off the main thread.
+    pub fn new(
+        config: Rc<DrawerConfig>,
+        well: gtk4::Box,
+        status_label: gtk4::Label,
+        state: Rc<RefCell<DrawerState>>,
+        on_launch: Rc<dyn Fn()>,
+    ) -> Self {
+        let (result_tx, result_rx) = async_channel::unbounded::<(u64, Vec<FileSearchRow>)>();
+        let generation = Rc::new(Cell::new(0u64));
+
+        // Result consumer — runs forever on the main loop, applying
+        // results that match the current generation.
+        let gen_consumer = Rc::clone(&generation);
+        glib::spawn_future_local(async move {
+            loop {
+                let (gen_id, rows) = match result_rx.recv().await {
+                    Ok(v) => v,
+                    Err(e) => {
+                        log::error!("file-search result channel closed: {e}");
+                        break;
+                    }
+                };
+                if gen_id != gen_consumer.get() {
+                    // User typed more after this worker started; results
+                    // are for a phrase the user has moved past.
+                    continue;
+                }
+                if rows.is_empty() {
+                    continue;
+                }
+                let count = rows.len();
+                let preferred_apps = state.borrow().preferred_apps.clone();
+                let widget = build_results_widget(&rows, &preferred_apps, Rc::clone(&on_launch));
+                widget.set_halign(gtk4::Align::Center);
+                well.append(&super::well_builder::divider());
+                well.append(&widget);
+                status_label.set_text(&format!(
+                    "{} file results | LMB: open | RMB: file manager",
+                    count
+                ));
+                // Up from first file result → back to app search results
+                super::navigation::install_file_results_nav(&widget);
+            }
+        });
+
+        Self {
+            generation,
+            pending_debounce: Cell::new(None),
+            result_tx,
+            config,
+        }
+    }
+
+    /// Schedules a debounced file-system walk for `phrase`. The walk
+    /// runs on a worker OS thread; results land on the consumer future.
+    pub fn dispatch(&self, phrase: &str, state: &Rc<RefCell<DrawerState>>) {
+        let gen_id = self.generation.get().wrapping_add(1);
+        self.generation.set(gen_id);
+        if let Some(id) = self.pending_debounce.take() {
+            id.remove();
+        }
+
+        // Snapshot Send-safe state under a tight borrow.
+        let phrase_owned = phrase.to_string();
+        let (user_dirs, exclusions) = {
+            let s = state.borrow();
+            (s.user_dirs.clone(), s.exclusions.clone())
+        };
+        let max = self.config.fs_max_results;
+        let tx = self.result_tx.clone();
+
+        let id = glib::timeout_add_local_once(
+            std::time::Duration::from_millis(FILE_SEARCH_DEBOUNCE_MS),
+            move || {
+                std::thread::spawn(move || {
+                    let rows = walk_for_search(&phrase_owned, &user_dirs, &exclusions, max);
+                    let _ = tx.send_blocking((gen_id, rows));
+                });
+            },
+        );
+        self.pending_debounce.set(Some(id));
+    }
+
+    /// Bumps the generation without dispatching. Call when the user
+    /// clears the search bar or switches to a non-search view —
+    /// any in-flight worker's results will be discarded.
+    pub fn invalidate(&self) {
+        self.generation.set(self.generation.get().wrapping_add(1));
+        if let Some(id) = self.pending_debounce.take() {
+            id.remove();
+        }
+    }
+}
+
+/// One result row from the file-system walk.
+///
+/// `Send + 'static` so the walker can run on a worker thread (issue #39)
+/// and ship the results back to the GTK main thread for widget
+/// construction.
+#[derive(Debug, Clone)]
+pub struct FileSearchRow {
+    /// Display path (relative to the XDG dir root).
+    pub display: String,
+    /// Full path, used for launching.
+    pub path: PathBuf,
+    /// Whether this is a directory (affects the icon).
+    pub is_dir: bool,
+}
+
+/// Walks all configured XDG user directories matching `phrase`, returning
+/// at most `max_results` rows sorted by display path.
+///
+/// Pure / Send-safe — operates on owned data only, no GTK references.
+/// Designed to run on a worker thread; the result vec is shipped back to
+/// the main thread via `async_channel` and rendered by [`build_results_widget`].
+pub fn walk_for_search(
     phrase: &str,
-    config: &DrawerConfig,
-    state: &Rc<RefCell<DrawerState>>,
-    on_launch: Rc<dyn Fn()>,
-) -> gtk4::Box {
-    let container = gtk4::Box::new(gtk4::Orientation::Vertical, 2);
+    user_dirs: &HashMap<XdgDirBucket, PathBuf>,
+    exclusions: &[String],
+    max_results: usize,
+) -> Vec<FileSearchRow> {
+    let mut all_results: Vec<FileSearchRow> = Vec::new();
 
-    let user_dirs = state.borrow().user_dirs.clone();
-    let exclusions = state.borrow().exclusions.clone();
-    let preferred_apps = state.borrow().preferred_apps.clone();
-
-    let mut all_results: Vec<(String, std::path::PathBuf, bool)> = Vec::new();
-
-    for (bucket, dir_path) in &user_dirs {
+    for (bucket, dir_path) in user_dirs {
         // Skip $HOME itself — walking the entire home tree is what every
         // other XDG dir is a more-targeted slice of.
-        if *bucket == crate::xdg_dirs::XdgDirBucket::Home || !dir_path.exists() {
+        if *bucket == XdgDirBucket::Home || !dir_path.exists() {
             continue;
         }
-        let remaining = config.fs_max_results.saturating_sub(all_results.len());
+        let remaining = max_results.saturating_sub(all_results.len());
         if remaining == 0 {
             break;
         }
-        for result in walk_directory(dir_path, phrase, &exclusions, remaining) {
+        for result in walk_directory(dir_path, phrase, exclusions, remaining) {
             let display = result
                 .path
                 .strip_prefix(dir_path)
                 .unwrap_or(&result.path)
                 .to_string_lossy()
                 .to_string();
-            all_results.push((display, result.path, result.is_dir));
+            all_results.push(FileSearchRow {
+                display,
+                path: result.path,
+                is_dir: result.is_dir,
+            });
         }
     }
 
     // Sort alphabetically by display name
-    all_results.sort_by_key(|a| a.0.to_lowercase());
+    all_results.sort_by_key(|r| r.display.to_lowercase());
+    all_results
+}
 
-    // Column header
-    if !all_results.is_empty() {
+/// Builds the GTK results widget from already-walked rows.
+///
+/// Stays on the main thread — uses `Rc<dyn Fn()>` for `on_launch` and
+/// constructs `gtk4` widgets. Caller is responsible for appending the
+/// returned `Box` to the well at the right position (after the divider).
+pub fn build_results_widget(
+    rows: &[FileSearchRow],
+    preferred_apps: &HashMap<String, String>,
+    on_launch: Rc<dyn Fn()>,
+) -> gtk4::Box {
+    let container = gtk4::Box::new(gtk4::Orientation::Vertical, 2);
+
+    if !rows.is_empty() {
         let header = gtk4::Box::new(gtk4::Orientation::Horizontal, 0);
         header.add_css_class("file-list-header");
 
@@ -69,16 +228,15 @@ pub fn search_files(
         container.append(&sep);
     }
 
-    // Result rows
-    for (display, file_path, is_dir) in &all_results {
-        let row = file_result_row(
-            display,
-            file_path,
-            *is_dir,
-            &preferred_apps,
+    for row in rows {
+        let widget = file_result_row(
+            &row.display,
+            &row.path,
+            row.is_dir,
+            preferred_apps,
             Rc::clone(&on_launch),
         );
-        container.append(&row);
+        container.append(&widget);
     }
 
     container

--- a/src/ui/well_builder.rs
+++ b/src/ui/well_builder.rs
@@ -10,6 +10,10 @@ use std::rc::Rc;
 /// Pinned items go into `pinned_box` (above the ScrolledWindow, fixed).
 /// App grid goes into `well` (inside the ScrolledWindow, scrollable).
 pub fn build_normal_well(ctx: &WellContext) {
+    // Drop any in-flight file-search worker so its results don't land
+    // on the now-normal-view well.
+    ctx.file_search.invalidate();
+
     clear_box(&ctx.well);
     clear_box(&ctx.pinned_box);
 
@@ -80,29 +84,17 @@ pub fn build_search_results(ctx: &WellContext, phrase: &str) {
     // Search results get navigation too (no cross-section targets)
     navigation::install_grid_nav(&app_flow, ctx.config.columns, None, None);
 
-    // File results
+    // File results — dispatched asynchronously. The walk runs on a worker
+    // thread; results appear in `ctx.well` via the consumer future spawned
+    // by `FileSearchDispatcher::new`. Stale results from prior keystrokes
+    // are dropped via the dispatcher's generation counter.
     if !ctx.config.no_fs && phrase.len() > 2 {
-        let file_results = ui::file_search::search_files(
-            phrase,
-            &ctx.config,
-            &ctx.state,
-            Rc::clone(&ctx.on_launch),
-        );
-        // file_search::search_files adds a header + separator before result rows
-        let total_children = count_children(&file_results);
-        let file_count = total_children.saturating_sub(2);
-        if file_count > 0 {
-            ctx.well.append(&divider());
-            ctx.status_label.set_text(&format!(
-                "{} file results | LMB: open | RMB: file manager",
-                file_count
-            ));
-            file_results.set_halign(gtk4::Align::Center);
-            ctx.well.append(&file_results);
-
-            // Up from first file result → back to app search results
-            navigation::install_file_results_nav(&file_results);
-        }
+        ctx.file_search.dispatch(phrase, &ctx.state);
+    } else {
+        // Sub-three-character phrases or `--no-fs` mode: no file search.
+        // Bump the generation so any in-flight worker's results don't
+        // sneak into the well.
+        ctx.file_search.invalidate();
     }
 }
 
@@ -279,23 +271,13 @@ fn clear_box(container: &gtk4::Box) {
     }
 }
 
-fn divider() -> gtk4::Separator {
+pub(super) fn divider() -> gtk4::Separator {
     let sep = gtk4::Separator::new(gtk4::Orientation::Horizontal);
     sep.set_margin_top(super::constants::DIVIDER_VERTICAL_MARGIN);
     sep.set_margin_bottom(super::constants::DIVIDER_VERTICAL_MARGIN);
     sep.set_margin_start(super::constants::DIVIDER_SIDE_MARGIN);
     sep.set_margin_end(super::constants::DIVIDER_SIDE_MARGIN);
     sep
-}
-
-fn count_children(widget: &impl IsA<gtk4::Widget>) -> i32 {
-    let mut count = 0;
-    let mut child = widget.first_child();
-    while let Some(c) = child {
-        count += 1;
-        child = c.next_sibling();
-    }
-    count
 }
 
 /// Which rebuild path to take when refreshing the well.

--- a/src/ui/well_context.rs
+++ b/src/ui/well_context.rs
@@ -1,5 +1,6 @@
 use crate::config::DrawerConfig;
 use crate::state::DrawerState;
+use crate::ui::file_search::FileSearchDispatcher;
 use std::cell::RefCell;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -18,4 +19,8 @@ pub struct WellContext {
     pub on_launch: Rc<dyn Fn()>,
     pub status_label: gtk4::Label,
     pub search_entry: gtk4::SearchEntry,
+    /// Async dispatcher for file-system search. `dispatch(phrase)` runs
+    /// the walk on a worker thread and appends results to `well` via
+    /// the consumer future spawned at `WellContext` construction time.
+    pub file_search: Rc<FileSearchDispatcher>,
 }


### PR DESCRIPTION
## Summary

Closes #39. Wave 4 hot-path fix building on #40's `async_channel` pattern.

Per-keystroke file search used to walk every XDG user directory **synchronously on the GTK main thread**, freezing the search bar for hundreds of ms against modest trees and seconds against a heavy `~/Downloads`. The walk now runs on a worker OS thread and the main loop stays responsive.

## Architecture

| Piece | Role |
|---|---|
| `walk_for_search(phrase, user_dirs, exclusions, max) -> Vec<FileSearchRow>` | Pure / Send-safe extraction of the directory walk. Owns no GTK state; runs on a worker thread. |
| `build_results_widget(rows, preferred_apps, on_launch) -> gtk4::Box` | Main-thread half — takes already-walked rows, renders the columnar list. |
| `FileSearchDispatcher` *(new)* | `dispatch(phrase, state)` bumps a generation counter, cancels any pending 150 ms debounce, schedules a fresh debounce that spawns a worker thread; `invalidate()` bumps generation without dispatching (called from `build_normal_well` / `apply_category_filter`). A consumer future on the GTK main loop receives `(gen, rows)` from workers, drops stale generations, and appends results to the well. |
| `WellContext::file_search` | `Rc<FileSearchDispatcher>` plumbed through so existing builders can `dispatch` / `invalidate` without threading new state through every call. |

## What's still synchronous

App-grid filtering (subsequence match against in-memory `DesktopEntry` list) and the math evaluator. Both are fast and "feel-instant matters."

## Cancellation guarantees

- Stale workers' results dropped at the consumer via generation mismatch (works even mid-walk — we don't kill threads, we just discard their output).
- Pending debounces cancelled on the next `dispatch` / `invalidate`, so a fast typist doesn't accumulate scheduled work.
- At process shutdown, `result_tx` drops, the consumer logs the closed channel and exits cleanly (matches the listener channel-closure handling from #40).

## Behavior change

Before: every keystroke ran the walk synchronously, blocking the search bar.

After: app-grid + math results still appear instantly; file results trickle in ~150 ms after the typing pause. On a finished phrase the user perceives "instant search filter, file results appear after a beat" rather than "search bar locked up while drawer thinks."

## Verified

- [x] `cargo build` clean
- [x] `make lint` clean (fmt + clippy + test + deny + audit)
- [x] All 89 tests pass — existing `walk_directory_*` tests still cover the underlying walker (now reachable via `walk_for_search`)
- [x] Diff is `+234 / -65`, mostly the new dispatcher

## Removed

- `search_files` (synchronous public wrapper) — replaced by `dispatch`.
- `count_children` helper in `well_builder.rs` — was only used to count rows after the synchronous `search_files` call; the dispatcher counts via `rows.len()` directly.

## Smoke test focus

Type in the search bar against a heavy directory tree (`~/Downloads`, `~/Pictures`). Search bar should respond instantly to every keystroke; file matches should appear shortly after the pause. Pin/unpin and category switches should not see stale file results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * File search is now non-blocking with 150 ms debounce after each keystroke.
  * Directory traversal executes in the background, keeping the app responsive during search operations.
  * Other features like app-name results and math evaluator remain interactive while searching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->