### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.0] — 2026-05-04
 
-Code-quality refactor pass closing epic [#28](https://github.com/jasonherald/nwg-drawer/issues/28). 21 of 22 sub-issues addressed across 7 waves; integration-test issue [#50](https://github.com/jasonherald/nwg-drawer/issues/50) closed as wontfix. No public API breaks (binary-only crate); the file-search, pin-toggle, and signal-handling paths are materially faster, and the modifier-key fix in the capture-phase keyboard handler is the only intentional behavior change.
+This release improves responsiveness in file-search, pin-toggle, and signal/inotify update paths, and fixes keyboard capture behavior so modifier-only keypresses no longer steal focus.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] — 2026-05-04
+
+Code-quality refactor pass closing epic [#28](https://github.com/jasonherald/nwg-drawer/issues/28). 21 of 22 sub-issues addressed across 7 waves; integration-test issue [#50](https://github.com/jasonherald/nwg-drawer/issues/50) closed as wontfix. No public API breaks (binary-only crate); the file-search, pin-toggle, and signal-handling paths are materially faster, and the modifier-key fix in the capture-phase keyboard handler is the only intentional behavior change.
+
 ### Changed
 
 - Hardened category, search, and pin-toggle callbacks against re-entrant

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "nwg-drawer"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nwg-drawer"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT"


### PR DESCRIPTION
## Summary

Cuts v0.4.0 — the first release after the May 2026 code-quality refactor pass.

- `Cargo.toml` + `Cargo.lock`: 0.3.0 → 0.4.0
- `CHANGELOG.md`: `[Unreleased]` section converted to `[0.4.0] — 2026-05-04` with a release-summary preamble; fresh empty `[Unreleased]` added above

## What's in 0.4.0

Closes epic #28: 21 of 22 sub-issues addressed across 7 waves, plus #50 closed as wontfix. PRs that landed in this release: #29-#32, #34, #36, #38-#41, #44, #46, #51-#52, #56, #59, #61, #63-#68 (Sonar baseline + workflow housekeeping not counted).

**User-visible behavior changes** (only one is intentional):
- Capture-phase keyboard handler no longer grabs focus on modifier-only presses. Shift+Tab now navigates the grid as expected instead of yanking focus to the search bar on the modifier-down event.

**Performance highlights:**
- File search no longer freezes the UI on typing — async pipeline with 150 ms debounce + worker thread + generation-counted result drop. (#39)
- Signal/inotify events reach the UI immediately rather than after a 100 ms poll. (#40)
- Search-time keystroke overhead scales much better on large `.desktop` registries.

**Bug fixes** (selected):
- File-search debounce no longer crashes on rapid backspace.
- Pin-toggle save failure no longer silently reorders the pinned row on rollback.
- Math copy button handles negative values (`wl-copy --` arg terminator).
- Pin-indicator dots and other recent CSS rules now ship to fresh installs (data dir was a stub).

**Internal-only improvements** that don't earn changelog bullets but are large in aggregate:
- Magic numbers promoted to `ui/constants.rs` (#42).
- Module-level `//!` docs on every source file (#43).
- 4 duplicated patterns extracted into helpers (#45).
- 6-item idiomatic-Rust polish bundle (#46).
- Naming/folding cleanup including dropping `ui/search.rs` (#47).
- Power-bar priority rules extracted into a pure `pick_first_present` with 4 unit tests (#48).

## Post-merge release steps

After CodeRabbit review + merge, the song and dance:

1. Tag locally: `git tag -a v0.4.0 -m 'Release v0.4.0'`
2. Push tag: `git push origin v0.4.0`
3. Publish: `cargo publish`

`cargo publish --dry-run --allow-dirty` was clean before commit.

## Test plan

- [x] `make lint` — fmt + clippy + test + deny + audit clean
- [x] `cargo test` — 102 tests pass
- [x] `cargo publish --dry-run` — clean
- [x] Manual smoke test on the resident drawer + keybind — no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved responsiveness for file search, pin toggle, and signal/update flows.

* **Bug Fixes**
  * Modifier-only keypresses no longer steal focus during keyboard capture.
  * Fixed UI, debounce, rollback, path-rendering, `.desktop` override, and negative-number copy issues.

* **Chores**
  * Bumped release to v0.4.0 and added release notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->