### PR TITLE
Bump nwg-common 0.3 → 0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,9 +947,9 @@ dependencies = [
 
 [[package]]
 name = "nwg-common"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "111ad59638979205950c1536d42540a9140793d5dacdea521e9621e2b43bb73c"
+checksum = "37643d5e67cc883e6f973651366b758d574bfdfac030c4c233606bf15415f294"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Shared library (library + binaries all on the 0.3.x line)
-nwg-common = "0.3"
+nwg-common = "0.5"
 
 # GTK4 + Wayland layer shell
 gtk4 = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ name = "nwg-drawer"
 path = "src/main.rs"
 
 [dependencies]
-# Shared library (library + binaries all on the 0.3.x line)
+# Shared library (library + binaries on the 0.5.x line)
 nwg-common = "0.5"
 
 # GTK4 + Wayland layer shell


### PR DESCRIPTION
## Summary

Stay-current dep bump. `nwg-common` jumped two minor versions on crates.io while we were focused on the v0.4.0 epic.

| | Old | New |
|---|---|---|
| `nwg-common` | `0.3` | `0.5` |

## What changed upstream

Both 0.4.0 and 0.5.0 are additive — no breaking changes:

- **0.4.0**: `WmEvent::WorkspaceChanged { id, name }` emitted by the Hyprland (`workspacev2`) and Sway (`WorkspaceEvent` with `change: focus`) backends.
- **0.5.0**: `watch_css_rebindable(path, provider) -> CssWatchHandle` — atomic inotify rebinding to a different CSS file path at runtime.
- **0.3.1**: `WmOverride` gained `serde::Serialize`/`Deserialize` with kebab-case rename.

The drawer doesn't consume any of these APIs yet, so no consumer-side changes were needed.

## No CHANGELOG entry

Per the project rule (user-visible bullets only — implementation-detail churn doesn't earn an entry), this dep bump doesn't surface anything to drawer users and gets no CHANGELOG bullet.

## Test plan

- [x] `cargo build` — clean against the new dep
- [x] `make lint` — fmt + clippy + test + deny + audit clean
- [x] `cargo test` — 102 tests pass (unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a core shared library dependency to a newer major line to maintain compatibility and stability across the project components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->