### PR TITLE
README: clarify --wm uwsm is opt-in for non-systemd users

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,26 @@ nwg-drawer --opacity 88 --pb-auto --columns 8
 
 # Resident mode (stays in memory, toggle with signals)
 nwg-drawer -r --pb-auto
-
-# Force Sway backend (usually auto-detected)
-nwg-drawer --wm sway
 ```
+
+### Compositor backend (`--wm`)
+
+The drawer auto-detects Hyprland (via `HYPRLAND_INSTANCE_SIGNATURE`) or Sway (via `SWAYSOCK`) at startup. **Most users don't need `--wm` at all.**
+
+When you do want to override:
+
+| Value | Effect |
+|---|---|
+| _omitted_ (default) | Auto-detect from env vars; falls back to a null backend on Niri/river/Openbox/etc. |
+| `--wm hyprland` | Force the Hyprland IPC backend regardless of environment. |
+| `--wm sway` | Force the Sway IPC backend regardless of environment. |
+| `--wm uwsm` | Launch wrapper for [uwsm](https://github.com/Vladimir-csp/uwsm) (Universal Wayland Session Manager) sessions. **Compositor detection still falls through to the env vars** — this flag controls how launched apps are spawned, not which backend serves drawer IPC. |
+
+#### Note for Slackware, Void, Alpine, and other non-systemd distros
+
+`--wm uwsm` is for users running under a uwsm-managed Wayland session, which currently requires systemd. **If you're not on systemd, just don't pass `--wm uwsm` and the drawer works normally** — app launches go directly through the compositor's exec mechanism (Hyprland's `dispatch exec`, Sway's `exec`) or via `sh -c` for the null backend. No `uwsm` binary is ever invoked.
+
+The drawer has no `which uwsm` probe and no PATH check — the only place it would shell out to `uwsm` is when the user explicitly opts in with `--wm uwsm`. Even there, if the binary turns out to be missing the launcher logs a warning and falls back to direct launch (`sh -c`), so a misconfigured launcher still launches apps.
 
 ## Integration with the dock
 


### PR DESCRIPTION
## Summary

Users on Slackware, Void, Alpine, and other non-systemd distros have been asking whether nwg-drawer depends on uwsm. It doesn't — but the README didn't say so anywhere. Adding a focused subsection.

## What changed

New `### Compositor backend (--wm)` subsection under Usage:

- **Table** documenting all three `--wm` values (hyprland / sway / uwsm) with the key clarification that `uwsm` is a launch-wrapper, not a backend trigger — compositor detection still falls through to `HYPRLAND_INSTANCE_SIGNATURE` / `SWAYSOCK`.
- **Note for non-systemd distros** explaining they just don't pass `--wm uwsm` and everything works normally. App launches go through the compositor's exec mechanism (Hyprland's `dispatch exec`, Sway's `exec`) or `sh -c` for the null backend. No `uwsm` binary is ever invoked.
- **Graceful-fallback behavior** documented: if the user opts into `--wm uwsm` but the binary is missing, the launcher logs a warning and falls back to direct launch (`sh -c`).

The standalone `nwg-drawer --wm sway` line in the basic Usage block was redundant with the new table; removed.

Strictly documentation — no code change, no behavior change.

## Test plan

- [x] `make lint` — fmt + clippy + test + deny + audit clean
- [ ] README renders correctly on GitHub (table + headings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Enhanced usage examples with additional code snippets demonstrating implementation patterns
- Added documentation for Resident mode functionality
- Reorganized and clarified backend selection documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->